### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -213,7 +213,7 @@ impl JobHandle {
         let (run_container, logres) = tokio::join!(running_container, logres);
         let log = logres.with_context(|| anyhow!("Collecting logs for job on '{}'", endpoint_name))?;
         let run_container = run_container
-            .with_context(|| anyhow!("Running container {} failed"))
+            .with_context(|| anyhow!("Running container {} failed", container_id))
             .with_context(|| {
                 Self::create_job_run_error(
                     &job_id,


### PR DESCRIPTION
<!-- short summary -->

Without this, the error message would literally be "Running container {} failed" with curly braces in it instead of the container id.


## Checklist

* [x] all commits are `--signoff` ([Why?](/CONTRIBUTING.md))
* [x] No `!fixup` commits in the PR
* [x] I ran `cargo check --all --tests`
* [ ] I ran `cargo test`
* [ ] I ran `cargo clippy`

