### PR TITLE
Fix dependency string for ascii_table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 anyhow         = "1"
 aquamarine     = "0.1"
-ascii_table    = ">= 3.0.2"
+ascii_table    = "^3.0.2"
 atty           = "0.2"
 bytesize       = "1"
 chrono         = "0.4"


### PR DESCRIPTION
The dependency string was too lax, as we cannot build against
ascii_table 4.0.0, because the API changed.

This fix changes the dependency string to not update major versions.


