### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  # Disable the pull request limit for dependabot
+  open-pull-requests-limit: 0
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   # Disable the pull request limit for dependabot
   open-pull-requests-limit: 0
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly


### PR DESCRIPTION
Adds a dependabot configuration.

This should wait until #32 is fully implemented! **Do not merge before**, as this will be the battle-test for the changes from #32!