### PR TITLE
Fix: Number of args for --env in "build" subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,7 +465,7 @@ pub fn cli() -> Command {
 
             .arg(Arg::new("env")
                 .required(false)
-                .num_args(0)
+                .num_args(1)
                 .short('E')
                 .long("env")
                 .value_parser(ValueParser::new(env_pass_validator))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@ use clap::crate_authors;
 use clap::crate_version;
 use clap::Command;
 use clap::Arg;
+use clap::ArgAction;
 use clap::ArgGroup;
 use clap::builder::PossibleValuesParser;
 use clap::builder::ValueParser;
@@ -467,6 +468,7 @@ pub fn cli() -> Command {
                 .required(false)
                 .num_args(1)
                 .short('E')
+                .action(ArgAction::Set)
                 .long("env")
                 .value_parser(ValueParser::new(env_pass_validator))
                 .help("Pass environment variable to all build jobs")


### PR DESCRIPTION
Fixes: a53f3bfd0622f1ee955af053c52f1d1577695c90 ("Rewrite value fetching")

Extracted from #43 
Closes #42 

---

I guess this closes #42, but please test. As far as I can see this patch is still valid, but YMMV.