### PR TITLE
Show which package file caused the loading of the repository to fail

### DIFF
--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -136,7 +136,8 @@ impl Repository {
                         config.set_once("patches", config::Value::from(patches))?;
                         Ok(config)
                     })
-                    .and_then(|c| c.try_into::<Package>().map_err(Error::from))
+                    .and_then(|c| c.try_into::<Package>().map_err(Error::from)
+                        .with_context(|| anyhow!("Could not load package configuration: {}", path.display())))
                     .map(|pkg| ((pkg.name().clone(), pkg.version().clone()), pkg))
             })
             .collect::<Result<BTreeMap<_, _>>>()


### PR DESCRIPTION
The error message didn't state which file caused the error:
```
$ butido source download hello
Error: Loading the repository

Caused by:
    missing field `name`
```

This makes it very difficult to find and fix the issue in the packages repository.

Now, the error message contains the location of the leaf package TOML file that caused the error:
```
$ butido source download hello
Error: Loading the repository

Caused by:
    0: Could not load package configuration: tree/1.42/pkg.toml
    1: missing field `name`
```

Signed-off-by: Michael Weiss <michael.weiss@atos.net>
Co-authored-by: Nico Steinle <nico.steinle@atos.net>
Tested-by: Michael Weiss <michael.weiss@atos.net>

<!-- short summary -->

What I did:


## Checklist

* [x] all commits are `--signoff` (Why? See CONTRIBUTING.md)
* [x] No `!fixup` commits in the PR
* [x] I ran `cargo check --all --tests`
* [x] I ran `cargo test`
* [x] I ran `cargo clippy`

