### PR TITLE
Include the package name and version in the logfile name

### DIFF
--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -475,7 +475,10 @@ impl<'a> LogReceiver<'a> {
     async fn get_logfile(&self) -> Option<Result<tokio::io::BufWriter<tokio::fs::File>>> {
         if let Some(log_dir) = self.log_dir.as_ref() {
             Some({
-                let path = log_dir.join(format!("{}.log", self.job_id));
+                let path = log_dir.join(format!(
+                    "{}-{}-{}.log",
+                    self.package_name, self.package_version, self.job_id
+                ));
                 tokio::fs::OpenOptions::new()
                     .create(true)
                     .create_new(true)


### PR DESCRIPTION
This makes it easier / more convenient for package developers to find the right log file as it avoids the need to lookup the UUID first.

We decided to prepend the package name and version so that the shell's tab completion functionality can be used to discover the filenames and globbing could also be useful.

This implements most of #50 (we just don't include the short Linux distribution name yet).

Signed-off-by: Michael Weiss <michael.weiss@atos.net>
Co-authored-by: Nico Steinle <nico.steinle@atos.net>
Tested-by: Michael Weiss <michael.weiss@atos.net>

<!-- short summary -->

What I did:


## Checklist

* [x] all commits are `--signoff` (Why? See CONTRIBUTING.md)
* [x] No `!fixup` commits in the PR
* [ ] I ran `cargo check --all --tests`
* [ ] I ran `cargo test`
* [ ] I ran `cargo clippy`

