### PR TITLE
Show the image/distro name in the log file

### DIFF
--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -136,7 +136,7 @@ fn cli(db_connection_config: DbConnectionConfig<'_>, matches: &ArgMatches) -> Re
         .map(|s| vec![s])
         .unwrap_or_else(|| vec!["psql", "pgcli"])
         .into_iter()
-        .filter_map(|s| which::which(&s).ok().map(|path| (path, s)))
+        .filter_map(|s| which::which(s).ok().map(|path| (path, s)))
         .map(|(path, s)| match s {
             "psql" => Ok(Box::new(Psql(path)) as Box<dyn PgCliCommand>),
             "pgcli" => Ok(Box::new(PgCli(path)) as Box<dyn PgCliCommand>),

--- a/src/db/find_artifacts.rs
+++ b/src/db/find_artifacts.rs
@@ -171,7 +171,7 @@ impl<'a> FindArtifacts<'a> {
 
                 let job = tpl.1;
                 let job_env: Vec<(String, String)> = job
-                    .env(&*self.database_connection)?
+                    .env(&self.database_connection)?
                     .into_iter()
                     .map(|var: dbmodels::EnvVar| (var.name, var.value))
                     .collect();
@@ -186,7 +186,7 @@ impl<'a> FindArtifacts<'a> {
                 Ok((_, bl)) => *bl,
             })
             .and_then_ok(|(art, _)| {
-                if let Some(release) = art.get_release(&*self.database_connection)? {
+                if let Some(release) = art.get_release(&self.database_connection)? {
                     Ok((art, Some(release.release_date)))
                 } else {
                     Ok((art, None))

--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -230,7 +230,7 @@ impl Endpoint {
 
     pub async fn prepare_container(
         &self,
-        job: RunnableJob,
+        job: &RunnableJob,
         staging_store: Arc<RwLock<StagingStore>>,
         release_stores: Vec<Arc<ReleaseStore>>,
     ) -> Result<PreparedContainer<'_>> {
@@ -453,18 +453,18 @@ pub struct PreparedContainer<'a> {
 impl<'a> PreparedContainer<'a> {
     async fn new(
         endpoint: &'a Endpoint,
-        job: RunnableJob,
+        job: &RunnableJob,
         staging_store: Arc<RwLock<StagingStore>>,
         release_stores: Vec<Arc<ReleaseStore>>,
     ) -> Result<PreparedContainer<'a>> {
         let script = job.script().clone();
-        let create_info = Self::build_container(endpoint, &job).await?;
+        let create_info = Self::build_container(endpoint, job).await?;
         let container = endpoint.docker.containers().get(&create_info.id);
 
         let (cpysrc, cpypch, cpyart, cpyscr) = tokio::join!(
-            Self::copy_source_to_container(&container, &job),
-            Self::copy_patches_to_container(&container, &job),
-            Self::copy_artifacts_to_container(&container, &job, staging_store, &release_stores),
+            Self::copy_source_to_container(&container, job),
+            Self::copy_patches_to_container(&container, job),
+            Self::copy_artifacts_to_container(&container, job, staging_store, &release_stores),
             Self::copy_script_to_container(&container, &script)
         );
 


### PR DESCRIPTION
This fixes #50.
It will log the full image/distro name, not a shortened one.

Signed-off-by: Nico Steinle <nico.steinle@atos.net>
Co-authored-by: Michael Weiss <michael.weiss@atos.net>

<!-- short summary -->

What I did:


## Checklist

* [x] all commits are `--signoff` (Why? See CONTRIBUTING.md)
* [x] No `!fixup` commits in the PR
* [x] I ran `cargo check --all --tests`
* [x] I ran `cargo test`
* [x] I ran `cargo clippy`

