### PR TITLE
Shorten the header fields of the db jobs output

### DIFF
--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -451,8 +451,8 @@ fn jobs(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> {
         "Submit",
         "Job",
         "Time",
-        "Endpoint",
-        "Success",
+        "Host",
+        "Ok?",
         "Package",
         "Version",
     ]);


### PR DESCRIPTION
We decided to shorten the header fields by default so that we can add more columns in the future without exceeding the available line width. Fixes #49

Note: We only use the shortened header field names in the DB jobs 
output (table) so that the rest of the code still uses the same field 
names as in the structs and DB model.

Signed-off-by: Nico Steinle <nico.steinle@atos.net>
Co-authored-by: Michael Weiss <michael.weiss@atos.net>

<!-- short summary -->

What I did:


## Checklist

* [x] all commits are `--signoff` (Why? See CONTRIBUTING.md)
* [x] No `!fixup` commits in the PR
* [x] I ran `cargo check --all --tests`
* [x] I ran `cargo test`
* [x] I ran `cargo clippy`

