### PR TITLE
actions: Run optional clippy (linting) checks with the beta toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,24 @@ jobs:
     needs: [check]
     name: Lint
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.optional }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - beta
+        optional: [true]
+        include:
+          - rust: 1.64.0 # MSRV
+            optional: false
     steps:
       - uses: actions/checkout@v3.2.0
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0 # MSRV
+          toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
       - uses: swatinem/rust-cache@v2
-      - run: rustup component add clippy
       - name: cargo clippy
         run: cargo clippy --all --all-targets --all-features -- -D warnings
 


### PR DESCRIPTION
More recent toolchain versions come with additional clippy lints.
E.g., the current stable version is 1.65.0 and shows three additional
clippy warnings (compared to 1.64.0 / the MSRV). We already saw those
warnings locally (until aa10870).

We only make the check with the MSRV required, as contributors shouldn't
have to fix clippy warnings in other parts of the code (unrelated to
their PR; we'll fix any additional warnings when bumping the MSRV).

However, it is useful to also run the clippy check with a more recent
toolchain version so that we maintainers can noticed and fix new
warnings in advance (without having to run clippy locally).
This is implemented so that one sees the failing optional job (hopefully
that won't confuse contributors) but the "CI" job that is required for
bors will still pass.
Most contributors will likely use the stable version so using the beta
version for the check seems ideal to catch warnings in advance (so that
contributors don't see them when they run clippy locally).

Relevant GitHub actions documentation:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

Signed-off-by: Michael Weiss <michael.weiss@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

---

~~@matthiasbeyer what do you think about this? At first I thought it would be a good idea but now I'm not so sure anymore... :o A better alternative (if it can be implemented) might be to use `${{ matrix.rust }}` here as well and only enforce the check against the MSRV (since contributors shouldn't have to fix linting issues unrelated to their changes and those fixes should be in a dedicated commit).~~

---

~~With this change: https://github.com/primeos-work/butido/actions/runs/3695146494/jobs/6257271973
Without this change: https://github.com/science-computing/butido/actions/runs/3548987433/jobs/5960839002~~