### PR TITLE
Specify the MSRV the manifest and add MSRV comments for updating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.64.0
+          - 1.64.0 # MSRV
           - stable
           - beta
 
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.64.0
+          - 1.64.0 # MSRV
           - stable
           - beta
     steps:
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0
+          toolchain: 1.64.0 # MSRV
           override: true
       - uses: swatinem/rust-cache@v2
       - run: rustup component add clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,4 +63,6 @@ By that you agree to the
 >     maintained indefinitely and may be redistributed consistent with
 >     this project or the open source license(s) involved.
 
+## Bumping the MSRV
 
+Use `git grep -E '[0-9]+(\.[0-9]+){2}.+MSRV'` and update all matches.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
            "Matthias Beyer <mail@beyermatthias.de>",
           ]
 edition = "2018"
+rust-version = "1.64.0" # MSRV
 license = "EPL-2.0"
 
 description = "Linux package tool utilizing docker, postgres and toml"


### PR DESCRIPTION
That way, when updating the MSRV, one can git-grep the MSRV comments (to avoid forgetting to update it somewhere).
The manifest field is documented here:
https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

Signed-off-by: Michael Weiss <michael.weiss@atos.net>

<!-- Please read CONTRIBUTING.md first and consider the checklist -->
