### PR TITLE
Change the PR template for improved bors commit messages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,4 @@
-<!-- Please read CONTRIBUTING.md first and consider the checklist -->
+<details>
+<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
+<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
+</details>

--- a/bors.toml
+++ b/bors.toml
@@ -5,5 +5,6 @@ status = [
 
 delete_merged_branches = true
 
+# Required to drop the large HTML part from dependabot PRs and integrated into
+# our PR template (.github/PULL_REQUEST_TEMPLATE.md):
 cut_body_after = "<details>"
-


### PR DESCRIPTION
This should help contributors to avoid (unintentionally) "polluting" the
Git history with unnecessary extra information (questions, outdated
notes, etc.). We also don't want the HTML comments or other useless
parts of the PR template in bors' merge commit messages.

Example cases that we want to avoid:
- https://github.com/science-computing/butido/commit/4ec75563ab7dd0efe5c007413e3a439e4e78c5e4: The HTML comment from the GH PR template (invisible on the
  web UI / rendered Markdown).
- https://github.com/science-computing/butido/commit/efd94e3785618aebe24c3487322445c33b61fdb9: I didn't plan to include the "Tested via my fork:" part. It
  is useful but I'm not sure if those URLs will remain available forever
  (otherwise I would of course be fine with including the links).
- https://github.com/science-computing/butido/commit/9f52ac61c575abd548bd1a37a8969354cfc4c6e3: The old PR template (checklist, comments, etc.).
- https://github.com/science-computing/butido/commit/acac31a84d96d5ce63afe160cef88c7eea26caa3: We probably don't want the "Please test before merging." in
  the history as that was obviously resolved before.

Signed-off-by: Michael Weiss <michael.weiss@atos.net>