### PR TITLE
set dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
+    interval: monthly
+  open-pull-requests-limit: 30
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly


### PR DESCRIPTION
We already hit the limit of 10 open PRs,
so dependabot can not open new PRs at the moment.
With switching to monthly interval
we probably will get even more.
So a higher limit of 30 might be a start.