### PR TITLE
Switch to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,14 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - uses: swatinem/rust-cache@v2
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   test:
     needs: [check]
@@ -45,18 +42,14 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - uses: swatinem/rust-cache@v2
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --all-features
+        run: cargo test --all --all-features
 
   cargo-deny:
     needs: [check]
@@ -94,10 +87,9 @@ jobs:
             optional: false
     steps:
       - uses: actions/checkout@v3.2.0
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: clippy
       - uses: swatinem/rust-cache@v2
       - name: cargo clippy


### PR DESCRIPTION
actions-rs is deprecated, use dtolnay/rust-toolchain.

<details>
Lets see whether CI is green for this PR, I did not confirm the syntax of the yaml file yet.
</details>
