### PR TITLE
Bump the Rust edition from 2018 to 2021 and fix all clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
            "Christoph Prokop <christoph.prokop@atos.net>",
            "Matthias Beyer <mail@beyermatthias.de>",
           ]
-edition = "2018"
+edition = "2021"
 rust-version = "1.64.0" # MSRV
 license = "EPL-2.0"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1405,7 +1405,7 @@ fn dir_exists_validator(s: &str) -> Result<(), String> {
     if PathBuf::from(&s).is_dir() {
         Ok(())
     } else {
-        Err(format!("Directory does not exist: {}", s))
+        Err(format!("Directory does not exist: {s}"))
     }
 }
 
@@ -1479,7 +1479,7 @@ fn parse_date_from_string(s: &str) -> std::result::Result<(), String> {
                 .map(|_| ())
         })
         .or_else(|_| {
-            let s = format!("{} 00:00:00", s);
+            let s = format!("{s} 00:00:00");
             humantime::parse_rfc3339_weak(&s)
                 .map_err(|e| e.to_string())
                 .map(|_| ())

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -447,14 +447,14 @@ pub async fn build(
                 }
             })
             .try_for_each(|(i, line)| {
-                let lineno = format!("{:>4} | ", i).bright_black();
-                writeln!(outlock, "{}{}", lineno, line).map_err(Error::from)
+                let lineno = format!("{i:>4} | ").bright_black();
+                writeln!(outlock, "{lineno}{line}").map_err(Error::from)
             })?;
 
         writeln!(outlock, "\n\n")?;
         if error_catched {
             if let Some(last_phase) = last_phase {
-                writeln!(outlock, "\tJob errored in Phase '{}'", last_phase)?;
+                writeln!(outlock, "\tJob errored in Phase '{last_phase}'")?;
             }
             writeln!(outlock, "\n\n")?;
         } else {

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -783,7 +783,7 @@ fn releases(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &
         .load::<(models::Artifact, models::Package, models::Release, models::ReleaseStore)>(&conn)?
         .into_iter()
         .filter_map(|(art, pack, rel, rstore)| {
-            let p = config.releases_directory().join(rstore.store_name).join(&art.path);
+            let p = config.releases_directory().join(rstore.store_name).join(art.path);
 
             if p.is_file() {
                 Some(vec![

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -653,7 +653,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
             script_len = format!("{:<4}", data.0.script_text.lines().count()).cyan(),
             log_len = format!("{:<4}", data.0.log_text.lines().count()).cyan(),
         );
-        writeln!(out, "{}", s)?;
+        writeln!(out, "{s}")?;
 
         if let Some(envs) = env_vars {
             let s = indoc::formatdoc!(
@@ -665,7 +665,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
             "#,
                 envs = envs
             );
-            writeln!(out, "{}", s)?;
+            writeln!(out, "{s}")?;
         }
 
         if show_script {
@@ -689,7 +689,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
             "#,
                 script = script
             );
-            writeln!(out, "{}", s)?;
+            writeln!(out, "{s}")?;
         }
 
         if show_log {
@@ -709,7 +709,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
             "#,
                 log = log
             );
-            writeln!(out, "{}", s)?;
+            writeln!(out, "{s}")?;
         }
 
         Ok(())
@@ -734,7 +734,7 @@ fn log_of(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
         .map_err(Error::from)
         .and_then(|s| crate::log::ParsedLog::from_str(&s))?
         .into_iter()
-        .map(|line| line.display().and_then(|d| writeln!(lock, "{}", d).map_err(Error::from)))
+        .map(|line| line.display().and_then(|d| writeln!(lock, "{d}").map_err(Error::from)))
         .collect::<Result<Vec<()>>>()
         .map(|_| ())
 }

--- a/src/commands/dependencies_of.rs
+++ b/src/commands/dependencies_of.rs
@@ -93,7 +93,7 @@ pub async fn dependencies_of(
     tokio_stream::iter(iter)
         .map(|pp| pp.into_displayable())
         .try_for_each(|p| {
-            let r = writeln!(&mut outlock, "{}", p).map_err(anyhow::Error::from);
+            let r = writeln!(&mut outlock, "{p}").map_err(anyhow::Error::from);
             futures::future::ready(r)
         })
         .await

--- a/src/commands/endpoint.rs
+++ b/src/commands/endpoint.rs
@@ -497,9 +497,9 @@ async fn images_present(endpoint_names: Vec<EndpointName>,
                 .map(|config_img| (ep_imgs.contains(config_img), config_img))
                 .try_for_each(|(found, img_name)| {
                     if found {
-                        writeln!(lock, "found {img} in {ep}", img = img_name, ep = ep_name).map_err(Error::from)
+                        writeln!(lock, "found {img_name} in {ep_name}").map_err(Error::from)
                     } else {
-                        writeln!(lock, "{img} not found", img = img_name).map_err(Error::from)
+                        writeln!(lock, "{img_name} not found").map_err(Error::from)
                     }
                 })
         })

--- a/src/commands/endpoint_container.rs
+++ b/src/commands/endpoint_container.rs
@@ -67,30 +67,30 @@ pub async fn container(endpoint_names: Vec<EndpointName>,
         Some(("kill", matches)) => {
             confirm({
                 if let Some(sig) = matches.value_of("signal").as_ref() {
-                    format!("Really kill {} with {}?", container_id, sig)
+                    format!("Really kill {container_id} with {sig}?")
                 } else {
-                    format!("Really kill {}?", container_id)
+                    format!("Really kill {container_id}?")
                 }
             })?;
 
             kill(matches, container).await
         },
         Some(("delete", _)) => {
-            if confirm(format!("Really delete {}?", container_id))? {
+            if confirm(format!("Really delete {container_id}?"))? {
                 delete(container).await
             } else {
                 Ok(())
             }
         },
         Some(("start", _))      => {
-            if confirm(format!("Really start {}?", container_id))? {
+            if confirm(format!("Really start {container_id}?"))? {
                 start(container).await
             } else {
                 Ok(())
             }
         },
         Some(("stop", matches)) => {
-            if confirm(format!("Really stop {}?", container_id))? {
+            if confirm(format!("Really stop {container_id}?"))? {
                 stop(matches, container).await
             } else {
                 Ok(())
@@ -196,7 +196,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
                 .map(|s| format!("{:ind$}{s}", "", ind = ind, s = s))
                 .join("\n")
         })
-        .map(|s| format!("\n{}", s))
+        .map(|s| format!("\n{s}"))
         .map(Cow::from)
         .unwrap_or_else(|| Cow::from("None"))
     }
@@ -307,7 +307,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
                 .collect::<Vec<_>>()
                 .join("\n");
 
-            format!("\n{s}", s = s)
+            format!("\n{s}")
         })
         .unwrap_or_else(|| String::from("None"))
     },
@@ -320,7 +320,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
                     .map(|(k, v)| format!("{:ind$}{k}: {v}", "", ind = 8, k = k, v = v))
                     .collect::<Vec<_>>()
                     .join("\n");
-                format!("\n{s}", s = s)
+                format!("\n{s}")
             })
             .unwrap_or_else(|| String::from("None"))
     },
@@ -363,7 +363,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
                     })
                     .collect::<Vec<_>>()
                     .join("\n");
-                format!("\n{s}", s = s)
+                format!("\n{s}")
             })
             .unwrap_or_else(|| String::from("None"))
     },
@@ -396,7 +396,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
                                         .map(|(k, v)| format!("{:ind$}{k}: {v}", "", ind = 12, k = k, v = v))
                                         .collect::<Vec<_>>()
                                         .join("\n");
-                                    format!("\n{s}", s = s)
+                                    format!("\n{s}")
                                 })
                                 .collect::<Vec<_>>()
                                 .join("\n")
@@ -406,7 +406,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
                     })
                     .collect::<Vec<_>>()
                     .join("\n");
-                format!("\n{s}", s = s)
+                format!("\n{s}")
             })
             .unwrap_or_else(|| String::from("None"))
     },
@@ -442,7 +442,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
         .collect::<Vec<_>>()
         .join("\n");
 
-        format!("\n{}", s)
+        format!("\n{s}")
     },
 
     path = d.path,
@@ -483,7 +483,7 @@ async fn inspect(container: Container<'_>) -> Result<()> {
             .collect::<Vec<_>>()
             .join("\n");
 
-        format!("\n{}", s)
+        format!("\n{s}")
     }
     )).map_err(Error::from)
 }

--- a/src/commands/env_of.rs
+++ b/src/commands/env_of.rs
@@ -52,7 +52,7 @@ pub async fn env_of(matches: &ArgMatches, repo: Repository) -> Result<()> {
         .try_for_each(|pkg| {
             if let Some(hm) = pkg.environment() {
                 for (key, value) in hm {
-                    writeln!(stdout, "{} = '{}'", key, value)?;
+                    writeln!(stdout, "{key} = '{value}'")?;
                 }
             } else {
                 writeln!(stdout, "No environment")?;

--- a/src/commands/find_pkg.rs
+++ b/src/commands/find_pkg.rs
@@ -96,7 +96,7 @@ pub async fn find_pkg(
         })
         .map(|pp| pp.into_displayable())
         .try_for_each(|p| {
-            let r = writeln!(&mut outlock, "{}", p).map_err(anyhow::Error::from);
+            let r = writeln!(&mut outlock, "{p}").map_err(anyhow::Error::from);
             futures::future::ready(r)
         })
         .await

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -200,7 +200,7 @@ pub fn display_data<D: Display>(
         wtr.into_inner()
             .map_err(Error::from)
             .and_then(|t| String::from_utf8(t).map_err(Error::from))
-            .and_then(|text| writeln!(lock, "{}", text).map_err(Error::from))
+            .and_then(|text| writeln!(lock, "{text}").map_err(Error::from))
     } else if atty::is(atty::Stream::Stdout) {
         let mut ascii_table = ascii_table::AsciiTable {
             columns: Default::default(),
@@ -238,7 +238,7 @@ pub fn get_date_filter(name: &str, matches: &ArgMatches) -> Result<Option<chrono
                         .and_then(|d| d.elapsed().map_err(Error::from))
                 })
                 .or_else(|_| {
-                    let s = format!("{} 00:00:00", s);
+                    let s = format!("{s} 00:00:00");
                     trace!("Parsing time: '{}'", s);
                     humantime::parse_rfc3339_weak(&s)
                         .map_err(Error::from)

--- a/src/commands/what_depends.rs
+++ b/src/commands/what_depends.rs
@@ -95,7 +95,7 @@ pub async fn what_depends(
     tokio_stream::iter(iter)
         .map(|pp| pp.and_then(|p| p.into_displayable()))
         .try_for_each(|p| {
-            let r = writeln!(&mut outlock, "{}", p).map_err(anyhow::Error::from);
+            let r = writeln!(&mut outlock, "{p}").map_err(anyhow::Error::from);
             futures::future::ready(r)
         })
         .await

--- a/src/db/models/job.rs
+++ b/src/db/models/job.rs
@@ -91,7 +91,7 @@ impl Job {
             dsl::jobs
                 .filter(uuid.eq(job_uuid))
                 .first::<Job>(database_connection)
-                .with_context(|| format!("Finding created job in database: {}", job_uuid))
+                .with_context(|| format!("Finding created job in database: {job_uuid}"))
                 .map_err(Error::from)
         })
     }

--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -314,9 +314,7 @@ impl JobHandle {
             package_name = package_name.to_string().red(),
             package_version = package_version.to_string().red(),
 
-            docker_connect_string = format!("docker --host {endpoint_uri} exec -it {container_id} /bin/bash",
-                endpoint_uri = endpoint_uri,
-                container_id = container_id
+            docker_connect_string = format!("docker --host {endpoint_uri} exec -it {container_id} /bin/bash"
             ).yellow().bold(),
         ))
     }

--- a/src/log/item.rs
+++ b/src/log/item.rs
@@ -32,20 +32,20 @@ impl LogItem {
     pub fn display(&self) -> Result<Display> {
         match self {
             LogItem::Line(s) => Ok(Display(String::from_utf8(s.to_vec())?.normal())),
-            LogItem::Progress(u) => Ok(Display(format!("#BUTIDO:PROGRESS:{}", u).cyan())),
-            LogItem::CurrentPhase(p) => Ok(Display(format!("#BUTIDO:PHASE:{}", p).cyan())),
+            LogItem::Progress(u) => Ok(Display(format!("#BUTIDO:PROGRESS:{u}").cyan())),
+            LogItem::CurrentPhase(p) => Ok(Display(format!("#BUTIDO:PHASE:{p}").cyan())),
             LogItem::State(Ok(())) => Ok(Display("#BUTIDO:STATE:OK".to_string().green())),
-            LogItem::State(Err(s)) => Ok(Display(format!("#BUTIDO:STATE:ERR:{}", s).red())),
+            LogItem::State(Err(s)) => Ok(Display(format!("#BUTIDO:STATE:ERR:{s}").red())),
         }
     }
 
     pub fn raw(&self) -> Result<String> {
         match self {
             LogItem::Line(s) => String::from_utf8(s.to_vec()).map_err(Error::from),
-            LogItem::Progress(u) => Ok(format!("#BUTIDO:PROGRESS:{}", u)),
-            LogItem::CurrentPhase(p) => Ok(format!("#BUTIDO:PHASE:{}", p)),
+            LogItem::Progress(u) => Ok(format!("#BUTIDO:PROGRESS:{u}")),
+            LogItem::CurrentPhase(p) => Ok(format!("#BUTIDO:PHASE:{p}")),
             LogItem::State(Ok(())) => Ok("#BUTIDO:STATE:OK".to_string()),
-            LogItem::State(Err(s)) => Ok(format!("#BUTIDO:STATE:ERR:{}", s)),
+            LogItem::State(Err(s)) => Ok(format!("#BUTIDO:STATE:ERR:{s}")),
         }
     }
 }

--- a/src/log/parser.rs
+++ b/src/log/parser.rs
@@ -45,12 +45,12 @@ impl std::fmt::Debug for ParsedLog {
             match line {
                 LogItem::Line(l)         => {
                     let s = std::str::from_utf8(l).unwrap_or("ERROR UTF8 ENCODING");
-                    writeln!(f, "[{}] Line('{}')", i, s)?
+                    writeln!(f, "[{i}] Line('{s}')")?
                 },
-                LogItem::Progress(u)     => writeln!(f, "[{}] Progress({})", i, u)?,
-                LogItem::CurrentPhase(s) => writeln!(f, "[{}] Phase({})", i, s)?,
-                LogItem::State(Ok(_))    => writeln!(f, "[{}] State::OK", i)?,
-                LogItem::State(Err(_))   => writeln!(f, "[{}] State::Err", i)?,
+                LogItem::Progress(u)     => writeln!(f, "[{i}] Progress({u})")?,
+                LogItem::CurrentPhase(s) => writeln!(f, "[{i}] Phase({s})")?,
+                LogItem::State(Ok(_))    => writeln!(f, "[{i}] State::OK")?,
+                LogItem::State(Err(_))   => writeln!(f, "[{i}] State::Err")?,
             }
         }
 
@@ -153,9 +153,9 @@ mod tests {
         match e {
             LogItem::Line(buf) => {
                 let line = String::from_utf8(buf.to_vec()).unwrap();
-                format!("LogItem::Line({})", line)
+                format!("LogItem::Line({line})")
             }
-            other => format!("{:?}", other),
+            other => format!("{other:?}"),
         }
     }
 
@@ -165,7 +165,7 @@ mod tests {
         let p = parser();
         let r = p.parse(s.as_bytes());
 
-        assert!(r.is_ok(), "Not ok: {:?}", r);
+        assert!(r.is_ok(), "Not ok: {r:?}");
         let r = r.unwrap();
         assert_eq!(r, LogItem::Line("foo bar".bytes().collect()));
     }
@@ -176,7 +176,7 @@ mod tests {
         let p = parser();
         let r = p.parse(s.as_bytes());
 
-        assert!(r.is_ok(), "Not ok: {:?}", r);
+        assert!(r.is_ok(), "Not ok: {r:?}");
         let r = r.unwrap();
         assert_eq!(r, LogItem::Progress(1));
     }
@@ -187,7 +187,7 @@ mod tests {
         let p = parser();
         let r = p.parse(s.as_bytes());
 
-        assert!(r.is_ok(), "Not ok: {:?}", r);
+        assert!(r.is_ok(), "Not ok: {r:?}");
         let r = r.unwrap();
         assert_eq!(r, LogItem::Progress(100));
     }
@@ -198,7 +198,7 @@ mod tests {
         let p = parser();
         let r = p.parse(s.as_bytes());
 
-        assert!(r.is_ok(), "Not ok: {:?}", r);
+        assert!(r.is_ok(), "Not ok: {r:?}");
         let r = r.unwrap();
         assert_eq!(r, LogItem::Line("#BUTIDO:PROGRESS:-1".bytes().collect()));
     }
@@ -209,7 +209,7 @@ mod tests {
         let p = parser();
         let r = p.parse(s.as_bytes());
 
-        assert!(r.is_ok(), "Not ok: {:?}", r);
+        assert!(r.is_ok(), "Not ok: {r:?}");
         let r = r.unwrap();
         assert_eq!(
             r,
@@ -227,7 +227,7 @@ mod tests {
         let p = parser();
         let r = p.parse(s.as_bytes());
 
-        assert!(r.is_ok(), "Not ok: {:?}", r);
+        assert!(r.is_ok(), "Not ok: {r:?}");
         let r = r.unwrap();
         assert_eq!(
             r,

--- a/src/orchestrator/util.rs
+++ b/src/orchestrator/util.rs
@@ -32,7 +32,7 @@ pub struct ReceivedErrorDisplay<'a>(&'a HashMap<Uuid, Error>);
 
 impl<'a> std::fmt::Display for ReceivedErrorDisplay<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.iter().try_for_each(|(uuid, err)| writeln!(f, "{}: {}", uuid, err))
+        self.0.iter().try_for_each(|(uuid, err)| writeln!(f, "{uuid}: {err}"))
     }
 }
 

--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -712,8 +712,8 @@ mod tests {
         assert!(ps.iter().any(|p| *p.version() == pversion("1")));
 
         // Not in the tree:
-        assert!(!ps.iter().any(|p| *p.name() == pname("b")), "'b' should not be in tree, but is: {:?}", ps);
-        assert!(!ps.iter().any(|p| *p.version() == pversion("2")), "'2' should not be in tree, but is: {:?}", ps);
+        assert!(!ps.iter().any(|p| *p.name() == pname("b")), "'b' should not be in tree, but is: {ps:?}");
+        assert!(!ps.iter().any(|p| *p.version() == pversion("2")), "'2' should not be in tree, but is: {ps:?}");
     }
 
     // Test whether the dependency DAG is correctly build if a image is used, but not the one

--- a/src/package/dependency/build.rs
+++ b/src/package/dependency/build.rs
@@ -68,7 +68,7 @@ mod tests {
     fn test_parse_dependency() {
         let s: TestSetting = toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
         match s.setting {
-            BuildDependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {}", name),
+            BuildDependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {name}"),
             other => panic!("Unexpected deserialization to other variant: {:?}", other),
         }
     }
@@ -78,7 +78,7 @@ mod tests {
         let s: TestSetting = toml::from_str(r#"setting = { name = "foo", condition = { in_image = "bar"} }"#).expect("Parsing TestSetting failed");
         match s.setting {
             BuildDependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -100,7 +100,7 @@ mod tests {
 
         match s.setting {
             BuildDependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -121,7 +121,7 @@ mod tests {
         let s: TestSettings = toml::from_str(r#"settings = [{ name = "foo", condition = { in_image = "bar"} }]"#).expect("Parsing TestSetting failed");
         match s.settings.get(0).expect("Has not one dependency") {
             BuildDependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -142,7 +142,7 @@ mod tests {
 
         match s.settings.get(0).expect("Has not one dependency") {
             BuildDependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -163,7 +163,7 @@ mod tests {
 
         match s.settings.get(0).expect("Has not one dependency") {
             BuildDependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));

--- a/src/package/dependency/build.rs
+++ b/src/package/dependency/build.rs
@@ -69,7 +69,7 @@ mod tests {
         let s: TestSetting = toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
         match s.setting {
             BuildDependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {name}"),
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -83,7 +83,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -105,7 +105,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -126,7 +126,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -147,7 +147,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -168,7 +168,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 }

--- a/src/package/dependency/runtime.rs
+++ b/src/package/dependency/runtime.rs
@@ -83,7 +83,7 @@ mod tests {
 
         match s.setting {
             Dependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {name}"),
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -97,7 +97,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -119,7 +119,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -140,7 +140,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -161,7 +161,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -182,7 +182,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 
@@ -207,7 +207,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
 
         match s.settings.get(1).expect("Has not two dependencies") {
@@ -217,7 +217,7 @@ mod tests {
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("boogie"))));
             },
-            other => panic!("Unexpected deserialization to other variant: {:?}", other),
+            other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 }

--- a/src/package/dependency/runtime.rs
+++ b/src/package/dependency/runtime.rs
@@ -82,7 +82,7 @@ mod tests {
         let s: TestSetting = toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
 
         match s.setting {
-            Dependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {}", name),
+            Dependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {name}"),
             other => panic!("Unexpected deserialization to other variant: {:?}", other),
         }
     }
@@ -92,7 +92,7 @@ mod tests {
         let s: TestSetting = toml::from_str(r#"setting = { name = "foo", condition = { in_image = "bar"} }"#).expect("Parsing TestSetting failed");
         match s.setting {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -114,7 +114,7 @@ mod tests {
 
         match s.setting {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -135,7 +135,7 @@ mod tests {
         let s: TestSettings = toml::from_str(r#"settings = [{ name = "foo", condition = { in_image = "bar"} }]"#).expect("Parsing TestSetting failed");
         match s.settings.get(0).expect("Has not one dependency") {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -156,7 +156,7 @@ mod tests {
 
         match s.settings.get(0).expect("Has not one dependency") {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -177,7 +177,7 @@ mod tests {
 
         match s.settings.get(0).expect("Has not one dependency") {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -202,7 +202,7 @@ mod tests {
 
         match s.settings.get(0).expect("Has not one dependencies") {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "foo", "Expected 'foo', got {}", name);
+                assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
@@ -212,7 +212,7 @@ mod tests {
 
         match s.settings.get(1).expect("Has not two dependencies") {
             Dependency::Conditional { name, condition } => {
-                assert_eq!(name, "baz", "Expected 'baz', got {}", name);
+                assert_eq!(name, "baz", "Expected 'baz', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
                 assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("boogie"))));

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -150,10 +150,10 @@ impl<'a> std::fmt::Debug for DebugPackage<'a> {
         ))?;
 
         writeln!(f, "\tBuild Dependencies = ")?;
-        self.0.dependencies.build.iter().try_for_each(|d| writeln!(f, "\t\t{:?}", d))?;
+        self.0.dependencies.build.iter().try_for_each(|d| writeln!(f, "\t\t{d:?}"))?;
 
         writeln!(f, "\tRuntime Dependencies = ")?;
-        self.0.dependencies.runtime.iter().try_for_each(|r| writeln!(f, "\t\t{:?}", r))?;
+        self.0.dependencies.runtime.iter().try_for_each(|r| writeln!(f, "\t\t{r:?}"))?;
 
         writeln!(f, "\tPatches = ")?;
         self.0.patches.iter().try_for_each(|p| writeln!(f, "\t\t{}", p.display()))?;
@@ -161,26 +161,26 @@ impl<'a> std::fmt::Debug for DebugPackage<'a> {
         writeln!(f, "\tEnvironment = ")?;
         self.0.environment
             .as_ref()
-            .map(|hm| hm.iter().try_for_each(|(k, v)| writeln!(f, "\t\t{:?} = {}", k, v)))
+            .map(|hm| hm.iter().try_for_each(|(k, v)| writeln!(f, "\t\t{k:?} = {v}")))
             .transpose()?;
 
         writeln!(f, "\tAllowed Images = ")?;
 
         self.0.allowed_images
             .as_ref()
-            .map(|v| v.iter().try_for_each(|i| writeln!(f, "\t\t{:?}", i)))
+            .map(|v| v.iter().try_for_each(|i| writeln!(f, "\t\t{i:?}")))
             .transpose()?;
 
         writeln!(f, "\tDenied Images = ")?;
         self.0.denied_images
             .as_ref()
-            .map(|v| v.iter().try_for_each(|i| writeln!(f, "\t\t{:?}", i)))
+            .map(|v| v.iter().try_for_each(|i| writeln!(f, "\t\t{i:?}")))
             .transpose()?;
 
         writeln!(f, "\tPhases = ")?;
         self.0.phases
             .iter()
-            .try_for_each(|(k, _)| writeln!(f, "\t\t{:?} = ...", k))?;
+            .try_for_each(|(k, _)| writeln!(f, "\t\t{k:?} = ..."))?;
 
         Ok(())
     }

--- a/src/package/script.rs
+++ b/src/package/script.rs
@@ -189,7 +189,7 @@ impl<'a> ScriptBuilder<'a> {
                         name.as_str(),
                         // whack hack: insert empty line on top because unindent ignores the
                         // indentation of the first line, see commit message for more info
-                        format!("\n{}", text).unindent(),
+                        format!("\n{text}").unindent(),
                         name.as_str(),
                     ));
 
@@ -305,8 +305,7 @@ impl HelperDef for StateHelper {
                     Ok(())
                 }
                 other => Err(RenderError::new(format!(
-                    "Parameter must bei either 'OK' or 'ERR', '{}' is invalid",
-                    other
+                    "Parameter must bei either 'OK' or 'ERR', '{other}' is invalid"
                 ))),
             })
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -50,7 +50,7 @@ pub fn script_to_printable(
         if line_numbers {
             script
                 .lines_numbered()?
-                .map(|(i, s)| format!("{:>4} | {}", i, s))
+                .map(|(i, s)| format!("{i:>4} | {s}"))
                 .join("")
         } else {
             script.lines()?.join("")
@@ -58,7 +58,7 @@ pub fn script_to_printable(
     } else if line_numbers {
         script
             .lines_numbered()
-            .map(|(i, s)| format!("{:>4} | {}", i, s))
+            .map(|(i, s)| format!("{i:>4} | {s}"))
             .join("")
     } else {
         script.to_string()


### PR DESCRIPTION
All of these changes are basically automated. I checked the diffs and
manually performed a few basic butido checks. The individual changes
happened in the order of the commits.

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

---

Output from `cargo fix --edition`
```
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  crypto-common v0.1.6 (as host dependency) removed features: std
  diesel v1.4.8 (as host dependency) removed features: 32-column-tables, bitflags, chrono, default, postgres, pq-sys, serde_json, uuid, with-deprecated
  digest v0.10.6 (as host dependency) removed features: alloc, std
  either v1.8.0 (as host dependency) removed features: default, use_std
  getrandom v0.2.8 removed features: std
  libc v0.2.137 (as host dependency) removed features: extra_traits
  memchr v2.5.0 (as host dependency) removed features: use_std
  proc-macro2 v1.0.47 (as host dependency) removed features: span-locations
  tokio v1.23.0 removed features: windows-sys

    Checking butido v0.3.0 (/home/rustup/butido)
   Migrating src/main.rs from 2018 edition to 2021
       Fixed src/package/dag.rs (2 fixes)
       Fixed src/log/parser.rs (6 fixes)
    Finished dev [unoptimized + debuginfo] target(s) in 27.68s
```

I dropped the 8 `assert!` "fixes" as those were due to the `assert!` changes that shouldn't've been in ce01e6bc7c2b0f8681c9ac53552179c8dbd9f5e1.