### PR TITLE
actions: Improve the CI caching and simplify the cargo CLI options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
 
       - name: Run cargo check
         run: cargo check
@@ -47,6 +49,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
 
       - name: Run cargo test
         run: cargo test --all --all-features
@@ -67,6 +71,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3.2.0
       - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}
@@ -92,6 +98,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
       - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: "ci"
       - name: cargo clippy
         run: cargo clippy --all --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           shared-key: "ci"
 
       - name: Run cargo check
-        run: cargo check
+        run: cargo check --all-targets
 
   test:
     needs: [check]
@@ -53,7 +53,7 @@ jobs:
           shared-key: "ci"
 
       - name: Run cargo test
-        run: cargo test --all --all-features
+        run: cargo test
 
   cargo-deny:
     needs: [check]
@@ -101,7 +101,7 @@ jobs:
         with:
           shared-key: "ci"
       - name: cargo clippy
-        run: cargo clippy --all --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   # We need some "accummulation" job here because bors fails (timeouts) to
   # listen on matrix builds.
@@ -118,4 +118,3 @@ jobs:
     steps:
       - name: CI succeeded
         run: exit 0
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
         run: cargo test
 
   cargo-deny:
-    needs: [check]
     name: cargo-deny
     runs-on: ubuntu-latest
     strategy:
@@ -70,9 +69,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.2.0
-      - uses: swatinem/rust-cache@v2
-        with:
-          shared-key: "ci"
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ checklist before submitting a PR to avoid unnecessary PR/CI iteration cycles:
 
 * [ ] All commits are signed off (`--signoff` - Why? See below)
 * [ ] No `!fixup` (etc.) commits
-* [ ] I ran `cargo check --all --tests`
+* [ ] I ran `cargo check --all-targets`
 * [ ] I ran `cargo test`
-* [ ] I ran `cargo clippy`
+* [ ] I ran `cargo clippy --all-targets`
 
 ## Reporting issues / Questions
 


### PR DESCRIPTION
According to my tests this fixes/improves the GitHub Actions caching, I simplified and unified the cargo CLI options, and disabled the caching for cargo-deny as that likely doesn't work anyway. The details are explained in the individual commit messages.
<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

Edit: Oops, forgot to use `--signoff` - fixed with `git rebase --signoff` :)