### PR TITLE
Update diesel, diesel_migrations, uuid, and rand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.64.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
           - beta
 
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.64.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
           - beta
     steps:
@@ -85,7 +85,7 @@ jobs:
           - beta
         optional: [true]
         include:
-          - rust: 1.64.0 # MSRV
+          - rust: 1.65.0 # MSRV
             optional: false
     steps:
       - uses: actions/checkout@v3.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide 0.6.2",
  "object",
@@ -258,7 +258,7 @@ dependencies = [
  "typed-builder",
  "unindent",
  "url",
- "uuid 0.6.5",
+ "uuid",
  "vergen",
  "walkdir",
  "which",
@@ -297,12 +297,6 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -451,7 +445,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -460,7 +454,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -470,7 +464,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -482,7 +476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
@@ -494,7 +488,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -596,25 +590,27 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.8"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
+checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
 dependencies = [
  "bitflags",
  "byteorder",
  "chrono",
  "diesel_derives",
+ "itoa",
  "pq-sys",
  "serde_json",
- "uuid 0.6.5",
+ "uuid",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "1.4.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
+checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
 dependencies = [
+ "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -622,10 +618,11 @@ dependencies = [
 
 [[package]]
 name = "diesel_migrations"
-version = "1.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
+checksum = "e9ae22beef5e9d6fab9225ddb073c1c6c1a7a6ded5019d5da11d1e5c5adc34e2"
 dependencies = [
+ "diesel",
  "migrations_internals",
  "migrations_macros",
 ]
@@ -678,7 +675,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -717,7 +714,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
@@ -908,7 +905,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -1077,7 +1074,7 @@ dependencies = [
  "serde 1.0.160",
  "serde_derive",
  "toml 0.7.3",
- "uuid 1.3.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1241,7 +1238,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1326,7 +1323,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -1432,7 +1429,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1461,23 +1458,23 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "1.4.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860"
+checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
 dependencies = [
- "diesel",
+ "serde 1.0.160",
+ "toml 0.5.11",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "1.4.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
+checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1643,7 +1640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1722,7 +1719,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
@@ -2321,7 +2318,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2332,7 +2329,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2510,7 +2507,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
@@ -2562,7 +2559,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -2765,7 +2762,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2903,22 +2900,12 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
-dependencies = [
- "cfg-if 0.1.10",
- "rand",
- "serde 1.0.160",
-]
-
-[[package]]
-name = "uuid"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
 dependencies = [
  "getrandom",
+ "serde 1.0.160",
 ]
 
 [[package]]
@@ -2988,7 +2975,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -3013,7 +3000,7 @@ version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "diesel_derives",
  "itoa",
  "pq-sys",
+ "r2d2",
  "serde_json",
  "uuid",
 ]
@@ -1973,6 +1974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,6 +2198,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,22 +774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,6 +1882,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "pq-sys"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,13 +1976,32 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "fuchsia-zircon",
  "libc",
- "winapi",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,9 +107,9 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "aquamarine"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d79f0956913d725449e8264e6b460e30d96be324963c666dbf0fa5c2d59149"
+checksum = "df752953c49ce90719c7bf1fc587bc8227aed04732ea0c0f85e5397d7fdbd1a1"
 dependencies = [
  "include_dir",
  "itertools",
@@ -165,9 +171,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bincode"
@@ -175,7 +181,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -183,6 +189,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "block-buffer"
@@ -195,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "butido"
@@ -242,7 +254,7 @@ dependencies = [
  "result-inspect",
  "rlimit",
  "semver",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_json",
  "sha-1",
  "sha2",
@@ -252,7 +264,7 @@ dependencies = [
  "terminal_size",
  "tokio",
  "tokio-stream",
- "toml 0.7.3",
+ "toml 0.7.4",
  "tracing",
  "tracing-subscriber",
  "typed-builder",
@@ -306,15 +318,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.160",
+ "serde 1.0.163",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi",
@@ -322,22 +334,22 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1f23fa97e1d1641371b51f35535cb26959b8e27ab50d167a8b996b5bada819"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc5d93c358224b4d6867ef1356d740de2303e9892edc06c5340daeccd96bab"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "once_cell",
  "strsim",
@@ -345,28 +357,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a19591b2ab0e3c04b588a0e04ddde7b9eaa423646d1b4a8092879216bf47473"
+checksum = "a04ddfaacc3bc9e6ea67d024575fafc2a813027cf374b8f24f7bc233c6b6be12"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -394,7 +396,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom",
  "rust-ini",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde-hjson",
  "serde_json",
  "toml 0.5.11",
@@ -403,15 +405,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
 dependencies = [
  "encode_unicode",
  "lazy_static 1.4.0",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -510,7 +512,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -523,57 +525,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "daggy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91a9304e55e9d601a39ae4deaba85406d5c0980e106f65afcf0460e9af1e7602"
 dependencies = [
  "petgraph",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -590,11 +548,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.0.4"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
+checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.1",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -607,21 +565,21 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
+checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
 dependencies = [
- "proc-macro-error",
+ "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "diesel_migrations"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ae22beef5e9d6fab9225ddb073c1c6c1a7a6ded5019d5da11d1e5c5adc34e2"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
 dependencies = [
  "diesel",
  "migrations_internals",
@@ -629,10 +587,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.6"
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -829,7 +796,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -915,11 +882,11 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git2"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
+checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -936,9 +903,9 @@ checksum = "641b847f0375f4b2c595438eefc17a9c0fbf47b400cbdd1ad9332bf1e16b779d"
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -955,14 +922,14 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.6"
+version = "4.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035ef95d03713f2c347a72547b7cd38cbc9af7cd51e6099fb62d586d4a6dee3a"
+checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
 dependencies = [
  "log",
  "pest",
  "pest_derive",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_json",
  "thiserror",
 ]
@@ -1056,9 +1023,9 @@ dependencies = [
  "anstyle",
  "backtrace",
  "os_info",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_derive",
- "toml 0.7.3",
+ "toml 0.7.4",
  "uuid",
 ]
 
@@ -1132,7 +1099,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper",
- "pin-project 1.0.12",
+ "pin-project 1.1.0",
  "tokio",
 ]
 
@@ -1152,12 +1119,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -1201,11 +1167,12 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+checksum = "db45317f37ef454e6519b6c3ed7d377e5f23346f0823f86e65ca36912d1d0ef8"
 dependencies = [
  "console",
+ "instant",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
@@ -1228,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -1281,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1307,7 +1274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "ryu",
  "static_assertions",
@@ -1315,15 +1282,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.1+1.6.4"
+version = "0.15.2+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
+checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
 dependencies = [
  "cc",
  "libc",
@@ -1369,15 +1336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
@@ -1410,12 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "matchers"
@@ -1443,19 +1398,19 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c493c09323068c01e54c685f7da41a9ccf9219735c3766fbfd6099806ea08fbc"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
- "serde 1.0.160",
- "toml 0.5.11",
+ "serde 1.0.163",
+ "toml 0.7.4",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8ff27a350511de30cdabb77147501c36ef02e0451d957abea2f30caffb2b58"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
 dependencies = [
  "migrations_internals",
  "proc-macro2",
@@ -1488,14 +1443,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1535,16 +1489,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits 0.2.15",
 ]
 
 [[package]]
@@ -1592,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "onig"
@@ -1602,7 +1546,7 @@ version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1620,11 +1564,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "12df40a956736488b7b44fe79fe12d4f245bb5b3f5a1f6095e499760015be392"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1641,7 +1585,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1652,9 +1596,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
@@ -1678,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
- "serde 1.0.160",
+ "serde 1.0.163",
  "winapi",
 ]
 
@@ -1773,7 +1717,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1808,11 +1752,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
- "pin-project-internal 1.0.12",
+ "pin-project-internal 1.1.0",
 ]
 
 [[package]]
@@ -1828,13 +1772,13 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -1851,9 +1795,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plist"
@@ -1861,12 +1805,12 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd9647b268a3d3e14ff09c23201133a62589c658db02bb7388c7246aafe0590"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "indexmap",
  "line-wrap",
  "quick-xml",
- "serde 1.0.160",
- "time 0.3.20",
+ "serde 1.0.163",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -1877,9 +1821,9 @@ checksum = "07e2192780e9f8e282049ff9bffcaa28171e1cb0844f49ed5374e518ae6024ec"
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 
 [[package]]
 name = "ppv-lite86"
@@ -1922,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1940,7 +1884,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde-value",
  "tint",
 ]
@@ -1956,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -2032,7 +1976,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2041,7 +1985,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2057,13 +2001,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -2083,17 +2027,17 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "reqwest"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
@@ -2111,7 +2055,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -2161,11 +2105,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.18"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2225,18 +2169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
-
-[[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2245,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2259,7 +2197,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2270,9 +2208,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -2296,18 +2234,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2318,16 +2256,16 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2339,7 +2277,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2398,8 +2336,8 @@ dependencies = [
  "log",
  "mime",
  "openssl",
- "pin-project 1.0.12",
- "serde 1.0.160",
+ "pin-project 1.1.0",
+ "serde 1.0.163",
  "serde_json",
  "tar",
  "tokio",
@@ -2488,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2504,7 +2442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
 dependencies = [
  "bincode",
- "bitflags",
+ "bitflags 1.3.2",
  "flate2",
  "fnv",
  "lazy_static 1.4.0",
@@ -2512,7 +2450,7 @@ dependencies = [
  "onig",
  "plist",
  "regex-syntax 0.6.29",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_derive",
  "serde_json",
  "thiserror",
@@ -2545,15 +2483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,7 +2509,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2606,27 +2535,27 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
- "serde 1.0.160",
+ "serde 1.0.163",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -2657,9 +2586,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg",
  "bytes 1.4.0",
@@ -2681,7 +2610,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2737,16 +2666,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "toml"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_spanned",
  "toml_datetime",
  "toml_edit",
@@ -2754,21 +2683,21 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
- "serde 1.0.160",
+ "serde 1.0.163",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -2806,14 +2735,14 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2885,9 +2814,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -2919,7 +2848,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2930,12 +2859,12 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
- "serde 1.0.160",
+ "serde 1.0.163",
 ]
 
 [[package]]
@@ -2952,13 +2881,13 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.1.3"
+version = "8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
 dependencies = [
  "anyhow",
  "rustversion",
- "time 0.3.20",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -3001,9 +2930,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3011,24 +2940,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3038,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3048,22 +2977,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-streams"
@@ -3080,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3288,9 +3217,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69af645a61644c6dd379ade8b77cc87efb5393c988707bad12d3c8e00c50f669"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ config         = { version = "0.11", default-features = false, features = [ "tom
 csv            = "1"
 daggy          = { version = "0.8", features = [ "serde" ] }
 dialoguer      = "0.10"
-diesel         = { version = "2", features = ["postgres", "chrono", "uuid", "serde_json"] }
+diesel         = { version = "2", features = ["postgres", "chrono", "uuid", "serde_json", "r2d2"] }
 diesel_migrations = "2"
 filters        = "0.4"
 futures        = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ config         = { version = "0.11", default-features = false, features = [ "tom
 csv            = "1"
 daggy          = { version = "0.8", features = [ "serde" ] }
 dialoguer      = "0.10"
-diesel         = { version = "1", features = ["postgres", "chrono", "uuid", "serde_json"] }
-diesel_migrations = "1"
+diesel         = { version = "2", features = ["postgres", "chrono", "uuid", "serde_json"] }
+diesel_migrations = "2"
 filters        = "0.4"
 futures        = "0.3"
 getset         = "0.1"
@@ -74,7 +74,7 @@ tokio-stream   = "0.1"
 typed-builder  = "0.14"
 unindent       = "0.2"
 url            = { version = "2", features = ["serde"] }
-uuid           = { version = "0.6", features = ["serde", "v4"] }
+uuid           = { version = "1", features = ["serde", "v4"] }
 walkdir        = "2"
 which          = "4"
 xdg            = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Michael Weiss <michael.weiss@atos.net>", # @primeos-work
 ]
 edition = "2021"
-rust-version = "1.64.0" # MSRV
+rust-version = "1.65.0" # MSRV
 license = "EPL-2.0"
 
 description = "Linux package tool utilizing Docker, PostgreSQL, and TOML"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,16 +78,7 @@ uuid           = { version = "1", features = ["serde", "v4"] }
 walkdir        = "2"
 which          = "4"
 xdg            = "2"
-
-# Hard-code rand to 0.4.3:
-# - rand 0.4.5 depends on fuchsia-cprng which has an unclear license
-# - rand 0.4.4 is yanked
-# - rand 0.4.3 does not contain this dependency
-#
-# TODO: Drop or update the direct dependency on rand because of this licensing issue.
-# Upstream issue: https://github.com/rust-random/rand/issues/1071
-rand = "=0.4.3"
-
+rand = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,19 +79,12 @@ walkdir        = "2"
 which          = "4"
 xdg            = "2"
 
-# Hard-code rand to 0.4.3
+# Hard-code rand to 0.4.3:
+# - rand 0.4.5 depends on fuchsia-cprng which has an unclear license
+# - rand 0.4.4 is yanked
+# - rand 0.4.3 does not contain this dependency
 #
-# Reason for this is this dependency chain:
-# diesel -> uuid (0.6) -> rand (0.4)
-# but rand 0.4.5 depends on fuchsia-cprng which has an unclear license
-# rand 0.4.4 is yanked, rand 0.4.3 does not contain this dependency.
-#
-# We do not explicitely need this dependency, we just want to force cargo not to
-# link against rand 0.4.5 because of this licensing issue.
-#
-# The proper solution for this would be to update "uuid" in diesel or
-# to update "rand" in uuid 0.6.
-#
+# TODO: Drop or update the direct dependency on rand because of this licensing issue.
 # Upstream issue: https://github.com/rust-random/rand/issues/1071
 rand = "=0.4.3"
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Building butido is easy, assuming you have a Rust installation:
 cargo build --release # (remove --release for a debug build)
 ```
 
-Butido is built and tested with Rust 1.64.0 as MSRV.
+Butido is built and tested with Rust 1.65.0 as MSRV.
 
 
 ### (Development) Setup

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -15,6 +15,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -296,9 +297,11 @@ pub async fn build(
         .collect::<Result<Vec<()>>>()?;
 
     trace!("Setting up database jobs for Package, GitHash, Image");
-    let db_package = async { Package::create_or_fetch(&database_connection, package) };
-    let db_githash = async { GitHash::create_or_fetch(&database_connection, &hash_str) };
-    let db_image = async { Image::create_or_fetch(&database_connection, &image_name) };
+    let database_connection = Arc::new(Mutex::new(database_connection));
+    // TODO: Avoid the locking here!:
+    let db_package = async { Package::create_or_fetch(&mut database_connection.clone().lock().unwrap(), package) };
+    let db_githash = async { GitHash::create_or_fetch(&mut database_connection.clone().lock().unwrap(), &hash_str) };
+    let db_image = async { Image::create_or_fetch(&mut database_connection.clone().lock().unwrap(), &image_name) };
     let db_envs = async {
         additional_env
             .clone()
@@ -306,7 +309,7 @@ pub async fn build(
             .map(|(k, v)| async {
                 let k: EnvironmentVariableName = k; // hack to work around move semantics
                 let v: String = v; // hack to work around move semantics
-                EnvVar::create_or_fetch(&database_connection, &k, &v)
+                EnvVar::create_or_fetch(&mut database_connection.clone().lock().unwrap(), &k, &v)
             })
             .collect::<futures::stream::FuturesUnordered<_>>()
             .collect::<Result<Vec<EnvVar>>>()
@@ -322,7 +325,7 @@ pub async fn build(
     trace!("Database jobs for Package, GitHash, Image finished successfully");
     trace!("Creating Submit in database");
     let submit = Submit::create(
-        &database_connection,
+        &mut database_connection.clone().lock().unwrap(),
         &now,
         &submit_id,
         &db_image,
@@ -358,7 +361,6 @@ pub async fn build(
     trace!("Setting up job sets finished successfully");
 
     trace!("Setting up Orchestrator");
-    let database_connection = Arc::new(database_connection);
     let orch = OrchestratorSetup::builder()
         .progress_generator(progressbars)
         .endpoint_config(endpoint_configurations)
@@ -402,7 +404,7 @@ pub async fn build(
         let data = schema::jobs::table
             .filter(schema::jobs::dsl::uuid.eq(job_uuid))
             .inner_join(schema::packages::table)
-            .first::<(Job, Package)>(database_connection.as_ref())?;
+            .first::<(Job, Package)>(&mut *database_connection.as_ref().lock().unwrap())?;
 
         let number_log_lines = *config.build_error_lines();
         writeln!(

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -15,7 +15,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -27,6 +26,8 @@ use diesel::ExpressionMethods;
 use diesel::PgConnection;
 use diesel::QueryDsl;
 use diesel::RunQueryDsl;
+use diesel::r2d2::ConnectionManager;
+use diesel::r2d2::Pool;
 use itertools::Itertools;
 use tracing::{debug, info, trace, warn};
 use tokio::sync::RwLock;
@@ -58,7 +59,7 @@ pub async fn build(
     repo_root: &Path,
     matches: &ArgMatches,
     progressbars: ProgressBars,
-    database_connection: PgConnection,
+    database_pool: Pool<ConnectionManager<PgConnection>>,
     config: &Configuration,
     repo: Repository,
     repo_path: &Path,
@@ -297,11 +298,9 @@ pub async fn build(
         .collect::<Result<Vec<()>>>()?;
 
     trace!("Setting up database jobs for Package, GitHash, Image");
-    let database_connection = Arc::new(Mutex::new(database_connection));
-    // TODO: Avoid the locking here!:
-    let db_package = async { Package::create_or_fetch(&mut database_connection.clone().lock().unwrap(), package) };
-    let db_githash = async { GitHash::create_or_fetch(&mut database_connection.clone().lock().unwrap(), &hash_str) };
-    let db_image = async { Image::create_or_fetch(&mut database_connection.clone().lock().unwrap(), &image_name) };
+    let db_package = async { Package::create_or_fetch(&mut database_pool.get().unwrap(), package) };
+    let db_githash = async { GitHash::create_or_fetch(&mut database_pool.get().unwrap(), &hash_str) };
+    let db_image = async { Image::create_or_fetch(&mut database_pool.get().unwrap(), &image_name) };
     let db_envs = async {
         additional_env
             .clone()
@@ -309,7 +308,7 @@ pub async fn build(
             .map(|(k, v)| async {
                 let k: EnvironmentVariableName = k; // hack to work around move semantics
                 let v: String = v; // hack to work around move semantics
-                EnvVar::create_or_fetch(&mut database_connection.clone().lock().unwrap(), &k, &v)
+                EnvVar::create_or_fetch(&mut database_pool.get().unwrap(), &k, &v)
             })
             .collect::<futures::stream::FuturesUnordered<_>>()
             .collect::<Result<Vec<EnvVar>>>()
@@ -325,7 +324,7 @@ pub async fn build(
     trace!("Database jobs for Package, GitHash, Image finished successfully");
     trace!("Creating Submit in database");
     let submit = Submit::create(
-        &mut database_connection.clone().lock().unwrap(),
+        &mut database_pool.get().unwrap(),
         &now,
         &submit_id,
         &db_image,
@@ -366,7 +365,7 @@ pub async fn build(
         .endpoint_config(endpoint_configurations)
         .staging_store(staging_store)
         .release_stores(release_stores)
-        .database(database_connection.clone())
+        .database(database_pool.clone())
         .source_cache(source_cache)
         .submit(submit)
         .log_dir(if matches.get_flag("write-log-file") {
@@ -404,7 +403,7 @@ pub async fn build(
         let data = schema::jobs::table
             .filter(schema::jobs::dsl::uuid.eq(job_uuid))
             .inner_join(schema::packages::table)
-            .first::<(Job, Package)>(&mut *database_connection.as_ref().lock().unwrap())?;
+            .first::<(Job, Package)>(&mut *database_pool.get().unwrap())?;
 
         let number_log_lines = *config.build_error_lines();
         writeln!(

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -121,9 +121,9 @@ pub async fn build(
     {
         // Because we're loading always sequencially, to have a bit more spread over the endpoints,
         // shuffle the endpoints here. Not a perfect solution, but a working one.
-        use rand::Rng;
+        use rand::seq::SliceRandom;
         let mut rng = rand::thread_rng();
-        rng.shuffle(&mut endpoint_configurations);
+        endpoint_configurations.shuffle(&mut rng);
     }
     info!("Endpoint config build");
 

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -27,6 +27,10 @@ use diesel::ExpressionMethods;
 use diesel::JoinOnDsl;
 use diesel::QueryDsl;
 use diesel::RunQueryDsl;
+use diesel_migrations::embed_migrations;
+use diesel_migrations::EmbeddedMigrations;
+use diesel_migrations::HarnessWithOutput;
+use diesel_migrations::MigrationHarness;
 use itertools::Itertools;
 use tracing::{debug, info, trace, warn};
 
@@ -38,7 +42,7 @@ use crate::log::JobResult;
 use crate::package::Script;
 use crate::schema;
 
-diesel_migrations::embed_migrations!("migrations");
+pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 
 /// Implementation of the "db" subcommand
 pub fn db(
@@ -148,8 +152,11 @@ fn cli(db_connection_config: DbConnectionConfig<'_>, matches: &ArgMatches) -> Re
 }
 
 fn setup(conn_cfg: DbConnectionConfig<'_>) -> Result<()> {
-    let conn = conn_cfg.establish_connection()?;
-    embedded_migrations::run_with_output(&conn, &mut std::io::stdout()).map_err(Error::from)
+    let mut conn = conn_cfg.establish_connection()?;
+    HarnessWithOutput::write_to_stdout(&mut conn)
+        .run_pending_migrations(MIGRATIONS)
+        .map(|_| ())
+        .map_err(|e| anyhow!(e))
 }
 
 /// Implementation of the "db artifacts" subcommand
@@ -158,7 +165,7 @@ fn artifacts(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<(
 
     let csv = matches.get_flag("csv");
     let hdrs = crate::commands::util::mk_header(vec!["Path", "Released", "Job"]);
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let data = matches
         .get_one::<String>("job_uuid")
         .map(|s| uuid::Uuid::parse_str(s.as_ref()))
@@ -168,7 +175,7 @@ fn artifacts(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<(
                 .inner_join(schema::jobs::table)
                 .left_join(schema::releases::table)
                 .filter(schema::jobs::dsl::uuid.eq(job_uuid))
-                .load::<(models::Artifact, models::Job, Option<models::Release>)>(&conn)
+                .load::<(models::Artifact, models::Job, Option<models::Release>)>(&mut conn)
                 .map_err(Error::from)
         })
         .unwrap_or_else(|| {
@@ -176,7 +183,7 @@ fn artifacts(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<(
                 .inner_join(schema::jobs::table)
                 .left_join(schema::releases::table)
                 .order_by(schema::artifacts::id.asc())
-                .load::<(models::Artifact, models::Job, Option<models::Release>)>(&conn)
+                .load::<(models::Artifact, models::Job, Option<models::Release>)>(&mut conn)
                 .map_err(Error::from)
         })?
         .into_iter()
@@ -207,9 +214,9 @@ fn envvars(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()>
 
     let csv = matches.get_flag("csv");
     let hdrs = crate::commands::util::mk_header(vec!["Name", "Value"]);
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let data = dsl::envvars
-        .load::<models::EnvVar>(&conn)?
+        .load::<models::EnvVar>(&mut conn)?
         .into_iter()
         .map(|evar| vec![evar.name, evar.value])
         .collect::<Vec<_>>();
@@ -229,9 +236,9 @@ fn images(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
 
     let csv = matches.get_flag("csv");
     let hdrs = crate::commands::util::mk_header(vec!["Name"]);
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let data = dsl::images
-        .load::<models::Image>(&conn)?
+        .load::<models::Image>(&mut conn)?
         .into_iter()
         .map(|image| vec![image.name])
         .collect::<Vec<_>>();
@@ -247,24 +254,24 @@ fn images(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
 
 /// Implementation of the "db submit" subcommand
 fn submit(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> {
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let submit_id = matches.get_one::<String>("submit")
         .map(|s| uuid::Uuid::from_str(s.as_ref()))
         .transpose()
         .context("Parsing submit UUID")?
         .unwrap(); // safe by clap
 
-    let submit = models::Submit::with_id(&conn, &submit_id)
+    let submit = models::Submit::with_id(&mut conn, &submit_id)
         .with_context(|| anyhow!("Loading submit '{}' from DB", submit_id))?;
 
-    let githash = models::GitHash::with_id(&conn, submit.repo_hash_id)
+    let githash = models::GitHash::with_id(&mut conn, submit.repo_hash_id)
         .with_context(|| anyhow!("Loading GitHash '{}' from DB", submit.repo_hash_id))?;
 
     let jobs = schema::submits::table
         .inner_join(schema::jobs::table)
         .filter(schema::submits::uuid.eq(&submit_id))
         .select(schema::jobs::all_columns)
-        .load::<models::Job>(&conn)
+        .load::<models::Job>(&mut conn)
         .with_context(|| anyhow!("Loading jobs for submit = {}", submit_id))?;
 
     let n_jobs = jobs.len();
@@ -309,11 +316,11 @@ fn submit(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
     let header = crate::commands::util::mk_header(["Job", "Success", "Package", "Version", "Container", "Endpoint", "Image"].to_vec());
     let data = jobs.iter()
         .map(|job| {
-            let image = models::Image::fetch_for_job(&conn, job)?
+            let image = models::Image::fetch_for_job(&mut conn, job)?
                 .ok_or_else(|| anyhow!("Image for job {} not found", job.uuid))?;
-            let package = models::Package::fetch_for_job(&conn, job)?
+            let package = models::Package::fetch_for_job(&mut conn, job)?
                 .ok_or_else(|| anyhow!("Package for job {} not found", job.uuid))?;
-            let endpoint = models::Endpoint::fetch_for_job(&conn, job)?
+            let endpoint = models::Endpoint::fetch_for_job(&mut conn, job)?
                 .ok_or_else(|| anyhow!("Endpoint for job {} not found", job.uuid))?;
 
             Ok(vec![
@@ -339,7 +346,7 @@ fn submits(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()>
     let csv = matches.get_flag("csv");
     let limit = matches.get_one::<String>("limit").map(|s| s.parse::<i64>()).transpose()?;
     let hdrs = crate::commands::util::mk_header(vec!["Time", "UUID", "For Package", "For Package Version"]);
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
 
     let query = schema::submits::table
         .order_by(schema::submits::id.desc()) // required for the --limit implementation
@@ -380,7 +387,7 @@ fn submits(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()>
         };
 
         // Only load the IDs of the submits, so we can later use them to filter the submits
-        let submit_ids = query.select(schema::submits::id).load::<i32>(&conn)?;
+        let submit_ids = query.select(schema::submits::id).load::<i32>(&mut conn)?;
 
         schema::submits::table
             .order_by(schema::submits::id.desc()) // required for the --limit implementation
@@ -389,7 +396,7 @@ fn submits(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()>
             })
             .filter(schema::submits::id.eq_any(submit_ids))
             .select((schema::submits::all_columns, schema::packages::all_columns))
-            .load::<(models::Submit, models::Package)>(&conn)?
+            .load::<(models::Submit, models::Package)>(&mut conn)?
     } else if let Some(pkgname) = matches.get_one::<String>("for_pkg") {
         // Get all submits _for_ the package
         let query = query
@@ -404,7 +411,7 @@ fn submits(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()>
             query
         }
         .select((schema::submits::all_columns, schema::packages::all_columns))
-        .load::<(models::Submit, models::Package)>(&conn)?
+        .load::<(models::Submit, models::Package)>(&mut conn)?
     } else if let Some(limit) = limit {
         query
             .inner_join({
@@ -412,13 +419,13 @@ fn submits(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()>
             })
             .select((schema::submits::all_columns, schema::packages::all_columns))
             .limit(limit)
-            .load::<(models::Submit, models::Package)>(&conn)?
+            .load::<(models::Submit, models::Package)>(&mut conn)?
     } else {
         query.inner_join({
                 schema::packages::table.on(schema::submits::requested_package_id.eq(schema::packages::id))
             })
             .select((schema::submits::all_columns, schema::packages::all_columns))
-            .load::<(models::Submit, models::Package)>(&conn)?
+            .load::<(models::Submit, models::Package)>(&mut conn)?
     };
 
     // Helper to map (Submit, Package) -> Vec<String>
@@ -455,7 +462,7 @@ fn jobs(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgM
         "Version",
         "Distro",
     ]);
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let older_than_filter = get_date_filter("older_than", matches)?;
     let newer_than_filter = get_date_filter("newer_than", matches)?;
 
@@ -484,7 +491,7 @@ fn jobs(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgM
             })
             .inner_join(schema::job_envs::table)
             .select(schema::job_envs::job_id)
-            .load::<i32>(&conn)?;
+            .load::<i32>(&mut conn)?;
 
         debug!("Filtering for these IDs (because of env filter): {:?}", jids);
         sel = sel.filter(schema::jobs::dsl::id.eq_any(jids));
@@ -517,7 +524,7 @@ fn jobs(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgM
 
     let data = sel
         .order_by(schema::jobs::id.desc()) // required for the --limit implementation
-        .load::<(models::Job, models::Submit, models::Endpoint, models::Package, models::Image)>(&conn)?
+        .load::<(models::Job, models::Submit, models::Endpoint, models::Package, models::Image)>(&mut conn)?
         .into_iter()
         .rev() // required for the --limit implementation
         .map(|(job, submit, ep, package, image)| {
@@ -557,7 +564,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
     let show_log = matches.get_flag("show_log");
     let show_script = matches.get_flag("show_script");
     let csv = matches.get_flag("csv");
-    let conn = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let job_uuid = matches
         .get_one::<String>("job_uuid")
         .map(|s| uuid::Uuid::parse_str(s.as_ref()))
@@ -576,7 +583,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
             models::Endpoint,
             models::Package,
             models::Image,
-        )>(&conn)?;
+        )>(&mut conn)?;
 
     trace!("Parsing log");
     let parsed_log = crate::log::ParsedLog::from_str(&data.0.log_text)?;
@@ -614,7 +621,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
             Some({
                 models::JobEnv::belonging_to(&data.0)
                     .inner_join(schema::envvars::table)
-                    .load::<(models::JobEnv, models::EnvVar)>(&conn)?
+                    .load::<(models::JobEnv, models::EnvVar)>(&mut conn)?
                     .into_iter()
                     .map(|tpl| tpl.1)
                     .enumerate()
@@ -725,7 +732,7 @@ fn job(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMa
 
 /// Implementation of the subcommand "db log-of"
 fn log_of(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> {
-    let conn   = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let job_uuid = matches
         .get_one::<String>("job_uuid")
         .map(|s| uuid::Uuid::parse_str(s.as_ref()))
@@ -737,7 +744,7 @@ fn log_of(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
     schema::jobs::table
         .filter(schema::jobs::dsl::uuid.eq(job_uuid))
         .select(schema::jobs::dsl::log_text)
-        .first::<String>(&conn)
+        .first::<String>(&mut conn)
         .map_err(Error::from)
         .and_then(|s| crate::log::ParsedLog::from_str(&s))?
         .into_iter()
@@ -749,7 +756,7 @@ fn log_of(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
 /// Implementation of the "db releases" subcommand
 fn releases(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &ArgMatches) -> Result<()> {
     let csv = matches.get_flag("csv");
-    let conn   = conn_cfg.establish_connection()?;
+    let mut conn = conn_cfg.establish_connection()?;
     let header = crate::commands::util::mk_header(["Package", "Version", "Date", "Path"].to_vec());
     let mut query = schema::jobs::table
         .inner_join(schema::packages::table)
@@ -787,7 +794,7 @@ fn releases(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &
             let rst = schema::release_stores::all_columns;
             (art, pac, rel, rst)
         })
-        .load::<(models::Artifact, models::Package, models::Release, models::ReleaseStore)>(&conn)?
+        .load::<(models::Artifact, models::Package, models::Release, models::ReleaseStore)>(&mut conn)?
         .into_iter()
         .filter_map(|(art, pack, rel, rstore)| {
             let p = config.releases_directory().join(rstore.store_name).join(art.path);

--- a/src/commands/find_artifact.rs
+++ b/src/commands/find_artifact.rs
@@ -13,6 +13,7 @@
 use std::path::PathBuf;
 use std::io::Write;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::convert::TryFrom;
 
 use anyhow::Context;
@@ -96,7 +97,7 @@ pub async fn find_artifact(matches: &ArgMatches, config: &Configuration, progres
         None
     };
 
-    let database = Arc::new(database_connection);
+    let database = Arc::new(Mutex::new(database_connection));
     repo.packages()
         .filter(|p| package_name_regex.captures(p.name()).is_some())
         .filter(|p| {

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -12,6 +12,8 @@
 
 use std::path::Path;
 use std::io::Write;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use anyhow::Error;
 use anyhow::Result;
@@ -44,16 +46,18 @@ pub async fn metrics(
         })
         .count();
 
-    let n_artifacts     = async { crate::schema::artifacts::table.count().get_result::<i64>(&conn) };
-    let n_endpoints     = async { crate::schema::endpoints::table.count().get_result::<i64>(&conn) };
-    let n_envvars       = async { crate::schema::envvars::table.count().get_result::<i64>(&conn) };
-    let n_githashes     = async { crate::schema::githashes::table.count().get_result::<i64>(&conn) };
-    let n_images        = async { crate::schema::images::table.count().get_result::<i64>(&conn) };
-    let n_jobs          = async { crate::schema::jobs::table.count().get_result::<i64>(&conn) };
-    let n_packages      = async { crate::schema::packages::table.count().get_result::<i64>(&conn) };
-    let n_releasestores = async { crate::schema::release_stores::table.count().get_result::<i64>(&conn) };
-    let n_releases      = async { crate::schema::releases::table.count().get_result::<i64>(&conn) };
-    let n_submits       = async { crate::schema::submits::table.count().get_result::<i64>(&conn) };
+    let conn = Arc::new(Mutex::new(conn));
+    // TODO: Avoid the locking here (makes async pointless)!:
+    let n_artifacts     = async { crate::schema::artifacts::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_endpoints     = async { crate::schema::endpoints::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_envvars       = async { crate::schema::envvars::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_githashes     = async { crate::schema::githashes::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_images        = async { crate::schema::images::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_jobs          = async { crate::schema::jobs::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_packages      = async { crate::schema::packages::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_releasestores = async { crate::schema::release_stores::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_releases      = async { crate::schema::releases::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
+    let n_submits       = async { crate::schema::submits::table.count().get_result::<i64>(&mut *conn.clone().lock().unwrap()) };
 
     let (
         n_artifacts,

--- a/src/db/models/image.rs
+++ b/src/db/models/image.rs
@@ -24,38 +24,38 @@ pub struct Image {
 }
 
 #[derive(Insertable)]
-#[table_name = "images"]
+#[diesel(table_name = images)]
 struct NewImage<'a> {
     pub name: &'a str,
 }
 
 impl Image {
     pub fn create_or_fetch(
-        database_connection: &PgConnection,
+        database_connection: &mut PgConnection,
         image_name: &ImageName,
     ) -> Result<Image> {
         let new_image = NewImage {
             name: image_name.as_ref(),
         };
 
-        database_connection.transaction::<_, Error, _>(|| {
+        database_connection.transaction::<_, Error, _>(|conn| {
             diesel::insert_into(images::table)
                 .values(&new_image)
                 .on_conflict_do_nothing()
-                .execute(database_connection)?;
+                .execute(conn)?;
 
             dsl::images
                 .filter(name.eq(image_name.as_ref()))
-                .first::<Image>(database_connection)
+                .first::<Image>(conn)
                 .map_err(Error::from)
         })
     }
 
-    pub fn fetch_for_job(database_connection: &PgConnection, j: &crate::db::models::Job) -> Result<Option<Image>> {
+    pub fn fetch_for_job(database_connection: &mut PgConnection, j: &crate::db::models::Job) -> Result<Option<Image>> {
         Self::fetch_by_id(database_connection, j.image_id)
     }
 
-    pub fn fetch_by_id(database_connection: &PgConnection, iid: i32) -> Result<Option<Image>> {
+    pub fn fetch_by_id(database_connection: &mut PgConnection, iid: i32) -> Result<Option<Image>> {
         match dsl::images.filter(id.eq(iid)).first::<Image>(database_connection) {
             Err(diesel::result::Error::NotFound) => Ok(None),
             Err(e) => Err(Error::from(e)),

--- a/src/db/models/job_env.rs
+++ b/src/db/models/job_env.rs
@@ -17,9 +17,9 @@ use crate::db::models::Job;
 use crate::schema::job_envs;
 
 #[derive(Identifiable, Queryable, Associations)]
-#[belongs_to(Job)]
-#[belongs_to(EnvVar, foreign_key = "env_id")]
-#[table_name = "job_envs"]
+#[diesel(belongs_to(Job))]
+#[diesel(belongs_to(EnvVar, foreign_key = env_id))]
+#[diesel(table_name = job_envs)]
 pub struct JobEnv {
     pub id: i32,
     pub job_id: i32,
@@ -27,14 +27,14 @@ pub struct JobEnv {
 }
 
 #[derive(Insertable)]
-#[table_name = "job_envs"]
+#[diesel(table_name = job_envs)]
 struct NewJobEnv {
     pub job_id: i32,
     pub env_id: i32,
 }
 
 impl JobEnv {
-    pub fn create(database_connection: &PgConnection, job: &Job, env: &EnvVar) -> Result<()> {
+    pub fn create(database_connection: &mut PgConnection, job: &Job, env: &EnvVar) -> Result<()> {
         let new_jobenv = NewJobEnv {
             job_id: job.id,
             env_id: env.id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,6 @@
 extern crate log as logcrate;
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_migrations;
 
 use std::path::PathBuf;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
         Some(("generate-completions", matches)) => generate_completions(matches),
         Some(("db", matches)) => crate::commands::db(db_connection_config, &config, matches)?,
         Some(("build", matches)) => {
-            let conn = db_connection_config.establish_connection()?;
+            let pool = db_connection_config.establish_pool()?;
 
             let repo = load_repo()?;
 
@@ -176,7 +176,7 @@ async fn main() -> Result<()> {
                 repo_path,
                 matches,
                 progressbars,
-                conn,
+                pool,
                 &config,
                 repo,
                 repo_path,
@@ -214,8 +214,8 @@ async fn main() -> Result<()> {
 
         Some(("find-artifact", matches)) => {
             let repo = load_repo()?;
-            let conn = db_connection_config.establish_connection()?;
-            crate::commands::find_artifact(matches, &config, progressbars, repo, conn)
+            let pool = db_connection_config.establish_pool()?;
+            crate::commands::find_artifact(matches, &config, progressbars, repo, pool)
                 .await
                 .context("find-artifact command failed")?
         }
@@ -256,8 +256,8 @@ async fn main() -> Result<()> {
 
         Some(("metrics", _)) => {
             let repo = load_repo()?;
-            let conn = db_connection_config.establish_connection()?;
-            crate::commands::metrics(repo_path, &config, repo, conn)
+            let pool = db_connection_config.establish_pool()?;
+            crate::commands::metrics(repo_path, &config, repo, pool)
                 .await
                 .context("metrics command failed")?
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ use anyhow::Result;
 use clap::ArgMatches;
 use logcrate::debug;
 use logcrate::error;
-use rand as _; // Required to make lints happy
 use aquamarine as _; // doc-helper crate
 
 mod cli;

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -21,6 +21,8 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use diesel::PgConnection;
+use diesel::r2d2::ConnectionManager;
+use diesel::r2d2::Pool;
 use git2::Repository;
 use indicatif::ProgressBar;
 use itertools::Itertools;
@@ -164,7 +166,7 @@ pub struct Orchestrator<'a> {
     jobdag: Dag,
     config: &'a Configuration,
     repository: Repository,
-    database: Arc<Mutex<PgConnection>>,
+    database: Pool<ConnectionManager<PgConnection>>,
 }
 
 #[derive(TypedBuilder)]
@@ -175,7 +177,7 @@ pub struct OrchestratorSetup<'a> {
     release_stores: Vec<Arc<ReleaseStore>>,
     source_cache: SourceCache,
     jobdag: Dag,
-    database: Arc<Mutex<PgConnection>>,
+    database: Pool<ConnectionManager<PgConnection>>,
     submit: dbmodels::Submit,
     log_dir: Option<PathBuf>,
     config: &'a Configuration,
@@ -455,7 +457,7 @@ struct TaskPreparation<'a> {
     scheduler: &'a EndpointScheduler,
     staging_store: Arc<RwLock<StagingStore>>,
     release_stores: Vec<Arc<ReleaseStore>>,
-    database: Arc<Mutex<PgConnection>>,
+    database: Pool<ConnectionManager<PgConnection>>,
 }
 
 /// Helper type for executing one job task
@@ -473,7 +475,7 @@ struct JobTask<'a> {
     scheduler: &'a EndpointScheduler,
     staging_store: Arc<RwLock<StagingStore>>,
     release_stores: Vec<Arc<ReleaseStore>>,
-    database: Arc<Mutex<PgConnection>>,
+    database: Pool<ConnectionManager<PgConnection>>,
 
     /// Channel where the dependencies arrive
     receiver: Receiver<JobResult>,
@@ -638,7 +640,7 @@ impl<'a> JobTask<'a> {
                 .collect::<Vec<_>>();
 
             let replacement_artifacts = crate::db::FindArtifacts::builder()
-                .database_connection(self.database.clone())
+                .database_pool(self.database.clone())
                 .config(self.config)
                 .package(self.jobdef.job.package())
                 .release_stores(&self.release_stores)

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -14,6 +14,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use anyhow::Error;
 use anyhow::Context;
@@ -163,7 +164,7 @@ pub struct Orchestrator<'a> {
     jobdag: Dag,
     config: &'a Configuration,
     repository: Repository,
-    database: Arc<PgConnection>,
+    database: Arc<Mutex<PgConnection>>,
 }
 
 #[derive(TypedBuilder)]
@@ -174,7 +175,7 @@ pub struct OrchestratorSetup<'a> {
     release_stores: Vec<Arc<ReleaseStore>>,
     source_cache: SourceCache,
     jobdag: Dag,
-    database: Arc<PgConnection>,
+    database: Arc<Mutex<PgConnection>>,
     submit: dbmodels::Submit,
     log_dir: Option<PathBuf>,
     config: &'a Configuration,
@@ -454,7 +455,7 @@ struct TaskPreparation<'a> {
     scheduler: &'a EndpointScheduler,
     staging_store: Arc<RwLock<StagingStore>>,
     release_stores: Vec<Arc<ReleaseStore>>,
-    database: Arc<PgConnection>,
+    database: Arc<Mutex<PgConnection>>,
 }
 
 /// Helper type for executing one job task
@@ -472,7 +473,7 @@ struct JobTask<'a> {
     scheduler: &'a EndpointScheduler,
     staging_store: Arc<RwLock<StagingStore>>,
     release_stores: Vec<Arc<ReleaseStore>>,
-    database: Arc<PgConnection>,
+    database: Arc<Mutex<PgConnection>>,
 
     /// Channel where the dependencies arrive
     receiver: Receiver<JobResult>,


### PR DESCRIPTION
This updates the last four crates that were restricted to outdated versions (apart from the `config` create which we decided not to update for now). The details are described in the individual commit messages. We have to bump the MSRV as well for the last commit (updating all crates in Cargo.lock).

~~Not much to see yet - still very incomplete.~~
PoC (untested) is ready ~~but we should certainly avoid the mutexes~~ (replaced via r2d2 connection pools).
Will supersede #81, #66, and #62.
~~TODO: Probably update `rand` as well (s. comment in Cargo.toml).~~ -> done
Reason for the MSRV bump:
```
error: package `time-core v0.1.1` cannot be built because it requires rustc 1.65.0 or newer, while the currently active rustc version is 1.64.0
```
<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->

```console
$ cargo update
    Updating crates.io index
      Adding android-tzdata v0.1.1
    Updating aquamarine v0.3.1 -> v0.3.2
    Updating base64 v0.21.0 -> v0.21.2
      Adding bitflags v2.3.1
    Updating bumpalo v3.12.1 -> v3.13.0
    Updating chrono v0.4.24 -> v0.4.25
    Updating clap v4.2.5 -> v4.3.0
    Updating clap_builder v4.2.5 -> v4.3.0
    Updating clap_complete v4.2.1 -> v4.3.0
    Updating clap_lex v0.4.1 -> v0.5.0
    Removing codespan-reporting v0.11.1
    Updating console v0.15.5 -> v0.15.7
    Removing cxx v1.0.94
    Removing cxx-build v1.0.94
    Removing cxxbridge-flags v1.0.94
    Removing cxxbridge-macro v1.0.94
    Updating diesel v2.0.4 -> v2.1.0
    Updating diesel_derives v2.0.2 -> v2.1.0
    Updating diesel_migrations v2.0.0 -> v2.1.0
      Adding diesel_table_macro_syntax v0.1.0
    Updating digest v0.10.6 -> v0.10.7
    Updating git2 v0.17.1 -> v0.17.2
    Updating h2 v0.3.18 -> v0.3.19
    Updating handlebars v4.3.6 -> v4.3.7
    Updating iana-time-zone-haiku v0.1.1 -> v0.1.2
    Updating indicatif v0.17.3 -> v0.17.4
    Updating io-lifetimes v1.0.10 -> v1.0.11
    Updating js-sys v0.3.61 -> v0.3.63
    Updating libc v0.2.142 -> v0.2.144
    Updating libgit2-sys v0.15.1+1.6.4 -> v0.15.2+1.6.4
    Removing link-cplusplus v1.0.8
    Updating linux-raw-sys v0.3.6 -> v0.3.8
    Updating log v0.4.17 -> v0.4.18
    Updating migrations_internals v2.0.0 -> v2.1.0
    Updating migrations_macros v2.0.0 -> v2.1.0
    Updating mio v0.8.6 -> v0.8.7
    Removing num-integer v0.1.45
    Updating once_cell v1.17.1 -> v1.17.2
    Updating openssl v0.10.52 -> v0.10.53
    Updating openssl-sys v0.9.87 -> v0.9.88
    Updating pin-project v1.0.12 -> v1.1.0
    Updating pin-project-internal v1.0.12 -> v1.1.0
    Updating pkg-config v0.3.26 -> v0.3.27
    Updating portable-atomic v0.3.19 -> v1.3.2
    Updating proc-macro2 v1.0.56 -> v1.0.59
    Updating quote v1.0.26 -> v1.0.28
    Updating regex v1.8.1 -> v1.8.3
    Updating regex-syntax v0.7.1 -> v0.7.2
    Updating reqwest v0.11.17 -> v0.11.18
    Updating rustix v0.37.18 -> v0.37.19
    Removing scratch v1.0.5
    Updating security-framework v2.8.2 -> v2.9.1
    Updating security-framework-sys v2.8.0 -> v2.9.0
    Updating serde v1.0.160 -> v1.0.163
    Updating serde_derive v1.0.160 -> v1.0.163
    Updating serde_spanned v0.6.1 -> v0.6.2
    Updating syn v2.0.15 -> v2.0.18
    Removing termcolor v1.2.0
    Updating time v0.3.20 -> v0.3.21
    Updating time-core v0.1.0 -> v0.1.1
    Updating time-macros v0.2.8 -> v0.2.9
    Updating tokio v1.28.0 -> v1.28.2
    Updating toml v0.7.3 -> v0.7.4
    Updating toml_datetime v0.6.1 -> v0.6.2
    Updating toml_edit v0.19.8 -> v0.19.10
    Updating tracing-core v0.1.30 -> v0.1.31
    Updating unicode-ident v1.0.8 -> v1.0.9
    Updating uuid v1.3.2 -> v1.3.3
    Updating vergen v8.1.3 -> v8.2.1
    Updating wasm-bindgen v0.2.84 -> v0.2.86
    Updating wasm-bindgen-backend v0.2.84 -> v0.2.86
    Updating wasm-bindgen-futures v0.4.34 -> v0.4.36
    Updating wasm-bindgen-macro v0.2.84 -> v0.2.86
    Updating wasm-bindgen-macro-support v0.2.84 -> v0.2.86
    Updating wasm-bindgen-shared v0.2.84 -> v0.2.86
    Updating web-sys v0.3.61 -> v0.3.63
    Updating winnow v0.4.5 -> v0.4.6
```
</details>
