### PR TITLE
Reset all display attributes at the end of each highlighted script line

### DIFF
--- a/src/package/script.rs
+++ b/src/package/script.rs
@@ -133,12 +133,15 @@ impl<'a> HighlightedScript<'a> {
 
         let mut h = HighlightLines::new(syntax, theme);
 
+        // To reset all (display) attributes (styles, colors, etc.) to their defaults:
+        let reset_all_attributes = "\x1b[0m";
+
         LinesWithEndings::from(&self.script.0)
             .map(move |line| -> Result<String> {
                 h
                     .highlight_line(line, &self.ps)
                     .with_context(|| anyhow!("Could not highlight the following line: {}", line))
-                    .map(|r| as_24_bit_terminal_escaped(&r[..], true))
+                    .map(|r| as_24_bit_terminal_escaped(&r[..], true) + reset_all_attributes)
             })
             .collect::<Result<Vec<String>>>()
             .map(|v| v.into_iter())


### PR DESCRIPTION
This is mostly important to reset the background at the end of the script (otherwise, the terminal will keep the background color until another command (re)sets it). Alternatively, we could only append "\x1b[0m" to the last line but this approach (adding the escape code after the newline character(s)) looks best to me (that way the background color will be kept until the end of the line).

With this change, the line numbers ("$i | ") will be printed without a background color but that could be considered a feature (without this change the line numbers were printed with the text color of the last highlighted character of the previous line so I do at least consider the current behaviour an improvement).

Ultimately, we should switch away from the `as_24_bit_terminal_escaped` function as it is only "meant for debugging and testing" and "is currently fairly inefficient in its use of escape codes".

[0]: https://docs.rs/syntect/5.0.0/syntect/util/fn.as_24_bit_terminal_escaped.html

Signed-off-by: Michael Weiss <michael.weiss@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
