### PR TITLE
Remove arrow prefix before list of built artifacts

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -388,7 +388,7 @@ pub async fn build(
         writeln!(outlock, "Packages created:")?;
     }
     artifacts.into_iter().try_for_each(|artifact_path| {
-        writeln!(outlock, "-> {}", staging_dir.join(artifact_path).display()).map_err(Error::from)
+        writeln!(outlock, "{}", staging_dir.join(artifact_path).display()).map_err(Error::from)
     })?;
 
     let mut had_error = false;

--- a/src/commands/source/mod.rs
+++ b/src/commands/source/mod.rs
@@ -134,7 +134,7 @@ where
     if results.iter().any(Result::is_err) {
         bar.finish_with_message("Source verification failed");
     } else {
-        bar.finish_with_message("Source verification successfull");
+        bar.finish_with_message("Source verification successful");
     }
 
     let out = std::io::stdout();


### PR DESCRIPTION
Makes it more convenient to copy the output line.
Fixes #138

Signed-off-by: Nico Steinle <nico.steinle@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
