### PR TITLE
Revert "Schedule to host where fewer containers are running"

### DIFF
--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -280,24 +280,6 @@ impl Endpoint {
             })
     }
 
-    pub async fn number_of_running_containers(&self) -> Result<usize> {
-        self.docker
-            .containers()
-            .list({
-                &shiplift::builder::ContainerListOptions::builder()
-                .all()
-                .build()
-            })
-            .await
-            .map_err(Error::from)
-            .map(|list| {
-                list.into_iter()
-                    .inspect(|stat| trace!("stat = {:?}", stat))
-                    .filter(|stat| stat.state == "running")
-                    .count()
-            })
-    }
-
     pub async fn has_container_with_id(&self, id: &str) -> Result<bool> {
         self.container_stats()
             .await?


### PR DESCRIPTION
This reverts commit 591fbd5afe536bea549009ee0e241e50c9375783.

Load balancer didn't balance within one submit.

For example submitting a target with 300 dependencies ended with almost all the jobs running on the same endpoint. Then for the next submit running on the next endpoint.

Fixes #51

Signed-off-by: Nico Steinle <nico.steinle@atos.net>
Co-authored-by: Michael Weiss <michael.weiss@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
