### PR TITLE
cargo-deny: Cleanup the ignore list for advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -64,22 +64,10 @@ skip-tree = [
 
 [advisories]
 ignore = [
-    # "linked-hash-map creates uninitialized NonNull pointer"
-    #
-    # This occours because our dependency "ptree" has old dependencies itself
-    # Patches to update its dependencies were submitted, but are not released
-    # yet.
-    "RUSTSEC-2020-0026",
-
     # "Potential segfault in the time crate"
     #
     # Patches available, but as "time-rs" is not a direct dependency, we cannot
     # do anything here
     "RUSTSEC-2020-0071",
-
-    # "Potential segfault in `localtime_r` invocations"
-    #
-    # No patches available yet
-    "RUSTSEC-2020-0159",
 ]
 


### PR DESCRIPTION
According to cargo-deny, those advisories were not encountered (`advisory-not-detected`) so we can stop ignoring them.

Signed-off-by: Michael Weiss <michael.weiss@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

An example for the relevant output: https://github.com/science-computing/butido/actions/runs/3957455462/jobs/6777847776#step:4:105