### PR TITLE
Replace env_logger with (tokio)tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,6 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "encoding_rs",
- "env_logger",
  "filters",
  "funty",
  "futures",
@@ -213,6 +212,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "typed-builder",
  "unindent",
  "url",
@@ -677,19 +678,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1243,18 +1231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1658,12 @@ checksum = "e24d44c0eea30167516ed8f6daca4b5e3eebcde1bde1e4e6e08b809fb02c7ba5"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -2288,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static 1.4.0",
+]
+
+[[package]]
 name = "shiplift"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,7 +2665,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2665,6 +2687,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static 1.4.0",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2766,6 +2814,12 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ daggy          = { version = "0.8", features = [ "serde" ] }
 dialoguer      = "0.10"
 diesel         = { version = "~1.4.6", features = ["postgres", "chrono", "uuid", "serde_json"] }
 diesel_migrations = "~1.4"
-env_logger     = "0.10"
 filters        = "0.4.0"
 futures        = "0.3"
 getset         = "0.1"
@@ -108,6 +107,8 @@ zeroize = ">=1.3.0, <1.6.0"
 # Make sure to remove this constraint as soon as possible.
 encoding_rs = ">=0.8.0, <=0.8.32"
 const_format = "0.2"
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 toml = "0.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use clap::Arg;
 use clap::ArgGroup;
 
 use const_format::formatcp;
-
+use tracing::{debug, error};
 
 // Helper types to ship around stringly typed clap API.
 pub const IDENT_DEPENDENCY_TYPE_BUILD: &str = "build";
@@ -1402,11 +1402,11 @@ fn env_pass_validator(s: &str) -> Result<(), String> {
 
     match parser.parse(s.as_bytes()).map_err(|e| e.to_string()) {
         Err(s) => {
-            log::error!("Error during validation: '{}' is not a key-value pair", s);
+            error!("Error during validation: '{}' is not a key-value pair", s);
             Err(s)
         }
         Ok((k, v)) => {
-            log::debug!("Env pass valiation: '{}={}'", k, v);
+            debug!("Env pass valiation: '{}={}'", k, v);
             Ok(())
         }
     }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -27,7 +27,7 @@ use diesel::PgConnection;
 use diesel::QueryDsl;
 use diesel::RunQueryDsl;
 use itertools::Itertools;
-use log::{debug, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use uuid::Uuid;

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -27,9 +27,7 @@ use diesel::JoinOnDsl;
 use diesel::QueryDsl;
 use diesel::RunQueryDsl;
 use itertools::Itertools;
-use log::debug;
-use log::info;
-use log::trace;
+use tracing::{debug, info, trace, warn};
 
 use crate::commands::util::get_date_filter;
 use crate::config::Configuration;
@@ -793,7 +791,7 @@ fn releases(conn_cfg: DbConnectionConfig<'_>, config: &Configuration, matches: &
                     p.display().to_string(),
                 ])
             } else {
-                log::warn!("Released file for {} {} not found: {}", pack.name, pack.version, p.display());
+                warn!("Released file for {} {} not found: {}", pack.name, pack.version, p.display());
                 None
             }
         })

--- a/src/commands/dependencies_of.rs
+++ b/src/commands/dependencies_of.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use clap::ArgMatches;
 use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
-use log::trace;
+use tracing::trace;
 
 use crate::commands::util::getbool;
 use crate::config::*;

--- a/src/commands/endpoint.rs
+++ b/src/commands/endpoint.rs
@@ -21,7 +21,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use clap::ArgMatches;
-use log::{debug, info, trace};
+use tracing::{debug, info, trace};
 use itertools::Itertools;
 use tokio_stream::StreamExt;
 

--- a/src/commands/env_of.rs
+++ b/src/commands/env_of.rs
@@ -14,7 +14,7 @@ use std::convert::TryFrom;
 
 use anyhow::Result;
 use clap::ArgMatches;
-use log::trace;
+use tracing::trace;
 
 use crate::package::PackageName;
 use crate::package::PackageVersionConstraint;

--- a/src/commands/find_artifact.rs
+++ b/src/commands/find_artifact.rs
@@ -21,8 +21,7 @@ use anyhow::Result;
 use clap::ArgMatches;
 use diesel::PgConnection;
 use itertools::Itertools;
-use log::debug;
-use log::trace;
+use tracing::{debug, trace};
 
 use crate::config::Configuration;
 use crate::filestore::ReleaseStore;
@@ -55,7 +54,7 @@ pub async fn find_artifact(matches: &ArgMatches, config: &Configuration, progres
         .map(String::from)
         .map(ImageName::from);
 
-    log::debug!("Finding artifacts for '{:?}' '{:?}'", package_name_regex, package_version_constraint);
+    debug!("Finding artifacts for '{:?}' '{:?}'", package_name_regex, package_version_constraint);
 
     let release_stores = config
         .release_stores()

--- a/src/commands/find_pkg.rs
+++ b/src/commands/find_pkg.rs
@@ -15,7 +15,7 @@ use std::convert::TryFrom;
 use anyhow::Context;
 use anyhow::Result;
 use clap::ArgMatches;
-use log::trace;
+use tracing::trace;
 use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
 

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -19,7 +19,7 @@ use anyhow::Error;
 use anyhow::Result;
 use clap::ArgMatches;
 use diesel::prelude::*;
-use log::{debug, error, info, trace};
+use tracing::{debug, error, info, trace};
 use tokio_stream::StreamExt;
 use resiter::AndThen;
 

--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -18,7 +18,7 @@ use anyhow::Error;
 use anyhow::Result;
 use anyhow::anyhow;
 use clap::ArgMatches;
-use log::{debug, trace};
+use tracing::{debug, trace};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;

--- a/src/commands/source/mod.rs
+++ b/src/commands/source/mod.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use clap::ArgMatches;
 use colored::Colorize;
-use log::{info, trace};
+use tracing::{info, trace};
 use tokio_stream::StreamExt;
 
 use crate::config::*;

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use clap::ArgMatches;
 use itertools::Itertools;
-use log::{error, info, trace};
+use tracing::{error, info, trace};
 use regex::Regex;
 use tokio_stream::StreamExt;
 

--- a/src/commands/versions_of.rs
+++ b/src/commands/versions_of.rs
@@ -13,7 +13,7 @@
 use anyhow::Error;
 use anyhow::Result;
 use clap::ArgMatches;
-use log::trace;
+use tracing::trace;
 
 use crate::package::PackageName;
 use crate::repository::Repository;

--- a/src/commands/what_depends.rs
+++ b/src/commands/what_depends.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use clap::ArgMatches;
 use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
-use log::trace;
+use tracing::trace;
 use resiter::Filter;
 use resiter::Map;
 

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -16,7 +16,7 @@ use clap::ArgMatches;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use getset::Getters;
-use log::debug;
+use tracing::debug;
 
 use crate::config::Configuration;
 

--- a/src/db/find_artifacts.rs
+++ b/src/db/find_artifacts.rs
@@ -20,7 +20,7 @@ use diesel::JoinOnDsl;
 use diesel::PgConnection;
 use diesel::QueryDsl;
 use diesel::RunQueryDsl;
-use log::trace;
+use tracing::{debug, trace};
 use resiter::AndThen;
 use resiter::FilterMap;
 
@@ -154,7 +154,7 @@ impl<'a> FindArtifacts<'a> {
             })
             .load::<(dbmodels::Artifact, dbmodels::Job)>(&*self.database_connection)?
             .into_iter()
-            .inspect(|(art, job)| log::debug!("Filtering further: {:?}, job {:?}", art, job.id))
+            .inspect(|(art, job)| debug!("Filtering further: {:?}, job {:?}", art, job.id))
             //
             // Filter by environment variables
             // All environment variables of the package must be present in the loaded

--- a/src/db/models/job.rs
+++ b/src/db/models/job.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use anyhow::Result;
 use diesel::prelude::*;
 use diesel::PgConnection;
-use log::trace;
+use tracing::trace;
 
 use crate::db::models::{Endpoint, Image, Package, Submit};
 use crate::package::Script;
@@ -81,7 +81,7 @@ impl Job {
             .values(&new_job)
             .on_conflict_do_nothing();
 
-        log::trace!("Query = {}", diesel::debug_query::<diesel::pg::Pg, _>(&query));
+        trace!("Query = {}", diesel::debug_query::<diesel::pg::Pg, _>(&query));
 
         database_connection.transaction::<_, Error, _>(|| {
             query

--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -19,7 +19,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use futures::FutureExt;
 use getset::{CopyGetters, Getters};
-use log::trace;
+use tracing::{trace, debug};
 use result_inspect::ResultInspect;
 use shiplift::Container;
 use shiplift::Docker;
@@ -592,7 +592,7 @@ impl<'a> PreparedContainer<'a> {
     ) -> Result<()> {
         use tokio::io::AsyncReadExt;
 
-        log::debug!("Copying patches to container: {:?}", job.package().patches());
+        debug!("Copying patches to container: {:?}", job.package().patches());
         job.package()
             .patches()
             .iter()

--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -19,7 +19,7 @@ use colored::Colorize;
 use diesel::PgConnection;
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use log::trace;
+use tracing::trace;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::UnboundedReceiver;

--- a/src/filestore/staging.rs
+++ b/src/filestore/staging.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use futures::stream::Stream;
 use indicatif::ProgressBar;
-use log::trace;
+use tracing::trace;
 use result_inspect::ResultInspect;
 
 use crate::filestore::path::ArtifactPath;

--- a/src/filestore/util.rs
+++ b/src/filestore/util.rs
@@ -15,6 +15,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use indicatif::ProgressBar;
+use tracing::trace;
 
 use crate::filestore::path::ArtifactPath;
 use crate::filestore::path::StoreRoot;
@@ -38,7 +39,7 @@ impl FileStoreImpl {
         let store = root_path
             .find_artifacts_recursive()
             .inspect(|path| {
-                log::trace!("Found artifact path: {:?}", path);
+                trace!("Found artifact path: {:?}", path);
                 progress.tick();
             })
             .collect::<Result<HashSet<ArtifactPath>>>()?;

--- a/src/job/runnable.rs
+++ b/src/job/runnable.rs
@@ -12,8 +12,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use getset::Getters;
-use log::debug;
-use log::trace;
+use tracing::{debug, trace};
 use uuid::Uuid;
 
 use crate::config::Configuration;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
         homepage: "atos.net/de/deutschland/sc".into(),
     });
 
-    env_logger::try_init()?;
+    tracing_subscriber::fmt::init();
     debug!("Debugging enabled");
 
     let app = cli::cli();

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -23,8 +23,7 @@ use diesel::PgConnection;
 use git2::Repository;
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use log::debug;
-use log::trace;
+use tracing::{debug, trace, error};
 use resiter::FilterMap;
 use tokio::sync::RwLock;
 use tokio::sync::mpsc::Receiver;
@@ -596,7 +595,7 @@ impl<'a> JobTask<'a> {
                 //
                 // We only send to one parent, because it doesn't matter
                 // And we know that we have at least one sender
-                log::error!("[{}]: Received errors = {}", self.jobdef.job.uuid(), received_errors.display_error_map());
+                error!("[{}]: Received errors = {}", self.jobdef.job.uuid(), received_errors.display_error_map());
                 self.sender[0].send(Err(received_errors)).await;
 
                 // ... and stop operation, because the whole tree will fail anyways.

--- a/src/orchestrator/util.rs
+++ b/src/orchestrator/util.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 /// Get a `Display`able interface for a Map of errors
 ///
 /// This is a helper trait for be able to display a `HashMap<Uuid, Error>`
-/// in a `log::trace!()` call, for example
+/// in a `tracing::trace!()` call, for example
 pub trait AsReceivedErrorDisplay {
     fn display_error_map(&self) -> ReceivedErrorDisplay<'_>;
 }

--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -20,7 +20,7 @@ use daggy::Walker;
 use getset::Getters;
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use log::trace;
+use tracing::trace;
 use ptree::Style;
 use ptree::TreeItem;
 use resiter::AndThen;

--- a/src/package/script.rs
+++ b/src/package/script.rs
@@ -21,7 +21,7 @@ use handlebars::{
     Context, Handlebars, Helper, HelperDef, HelperResult, JsonRender, Output, PathAndJson,
     RenderContext, RenderError,
 };
-use log::trace;
+use tracing::trace;
 use serde::Deserialize;
 use serde::Serialize;
 use syntect::easy::HighlightLines;

--- a/src/package/source.rs
+++ b/src/package/source.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use getset::Getters;
-use log::trace;
+use tracing::trace;
 use serde::Deserialize;
 use serde::Serialize;
 use url::Url;

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -16,7 +16,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
-use log::trace;
+use tracing::trace;
 use resiter::AndThen;
 use resiter::FilterMap;
 use resiter::Map;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -14,7 +14,7 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
-use log::trace;
+use tracing::trace;
 use url::Url;
 
 use crate::package::Package;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use anyhow::anyhow;
 use itertools::Itertools;
-use log::error;
+use tracing::error;
 
 use crate::config::Configuration;
 use crate::package::Script;

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -11,7 +11,7 @@
 use anyhow::Error;
 use anyhow::Result;
 use filters::failable::filter::FailableFilter;
-use log::trace;
+use tracing::trace;
 use resiter::Map;
 
 use crate::package::Package;
@@ -101,7 +101,7 @@ mod tests {
     use crate::repository::Repository;
 
     fn setup_logging() {
-        let _ = env_logger::try_init();
+        let _ = tracing_subscriber::fmt::try_init();
     }
 
     #[test]

--- a/src/util/git.rs
+++ b/src/util/git.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
 use git2::Repository;
-use log::trace;
+use tracing::trace;
 
 pub fn repo_is_clean(r: &Repository) -> Result<bool> {
     r.diff_index_to_workdir(None, None)


### PR DESCRIPTION
Because tokio tracing is better suited for logging in async code.
Partially fixes #55 

Signed-off-by: Nico Steinle <nico.steinle@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
