### PR TITLE
Bump libgit2-sys from v0.14.0+1.5.0 to v0.14.2+1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,9 +1335,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.0+1.5.0"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
To fix the advisories check from cargo-deny. It failed due to RUSTSEC-2023-0003 (git2 does not verify SSH keys by default) [0]. It shouldn't affect us as we don't use it for SSH communication (pushing/fetching) but it's of course better to update the crate than to ignore this advisory.

[0]: https://rustsec.org/advisories/RUSTSEC-2023-0003

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

```
error[vulnerability]: git2 does not verify SSH keys by default
    ┌─ /github/workspace/Cargo.lock:129:1
    │
129 │ libgit2-sys 0.14.0+1.5.0 registry+https://github.com/rust-lang/crates.io-index
advisories FAILED
    │ ------------------------------------------------------------------------------ security vulnerability detected
    │
    = ID: RUSTSEC-2023-0003
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0003
    = The git2 and libgit2-sys crates are Rust wrappers around the
      [libgit2]() C library. It was discovered that libgit2 1.5.0
      and below did not verify SSH host keys when establishing an SSH connection,
      exposing users of the library to Man-In-the-Middle attacks.
      
      The libgit2 team assigned [CVE-2023-22742][libgit2-advisory] to this
      vulnerability. The following versions of the libgit2-sys Rust crate have been
      released:
      
      * libgit2-sys 0.14.2, updating the underlying libgit2 C library to version 1.5.1.
      * libgit2-sys 0.13.5, updating the underlying libgit2 C library to version 1.4.5.
      
      A new git2 crate version has also been released, 0.16.1. This version only
      bumps its libgit2-sys dependency to ensure no vulnerable libgit2-sys versions
      are used, but contains no code changes: if you update the libgit2-sys version
      there is no need to also update the git2 crate version.
      
      [You can learn more about this vulnerability in libgit2's advisory][libgit2-advisory]
      
      [libgit2]: https://libgit2.org/
      [libgit2-advisory]: https://github.com/libgit2/libgit2/security/advisories/GHSA-[8](https://github.com/science-computing/butido/actions/runs/4013745447/jobs/6893445940#step:4:9)643-3wh5-rmjq
    = Announcement: https://github.com/rust-lang/git2-rs/security/advisories/GHSA-m4ch-rfv5-x5g3
    = Solution: Upgrade to >=0.[13](https://github.com/science-computing/butido/actions/runs/4013745447/jobs/6893445940#step:4:14).5, <0.[14](https://github.com/science-computing/butido/actions/runs/4013745447/jobs/6893445940#step:4:15).0 OR >=0.14.2
    = libgit2-sys v0.14.0+1.5.0
      └── git2 v0.[15](https://github.com/science-computing/butido/actions/runs/4013745447/jobs/6893445940#step:4:16).0
          ├── butido v0.3.0
          └── vergen v7.5.0
              └── (build) butido v0.3.0 (*)
[...]
advisories FAILED
```