### PR TITLE
Avoid a useless conversion to the same type

### DIFF
--- a/src/filestore/path.rs
+++ b/src/filestore/path.rs
@@ -99,7 +99,6 @@ impl StoreRoot {
         R: std::io::Read,
     {
         ar.entries()?
-            .into_iter()
             .map_err(Error::from)
             .filter_ok(|entry| entry.header().entry_type() == tar::EntryType::Regular)
             .and_then_ok(|mut entry| -> Result<_> {


### PR DESCRIPTION
These changes are from `cargo clippy --fix` (clippy 0.1.68).

Signed-off-by: Michael Weiss <michael.weiss@atos.net>

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

My plan was to resolve all clippy warnings to get CI green again but we currently cannot update `nom` due to our dependency on `config` (`config="0.11" -> nom = "5.0.0"`). So we either need to update or patch `config` (as `nom` is a required dependency). Relevant `config` commits: https://github.com/mehcode/config-rs/commit/4d8d633013b4f87d0790568731d09a3e97cd5163 and https://github.com/mehcode/config-rs/commit/b829a8e2e87452a8775e3389d5c5720238df20c4. (The changelog for the config crate: https://github.com/mehcode/config-rs/blob/master/CHANGELOG.md).

**Edit:** Looks like we cannot get rid of `config 0.11` anyway due to [ptree 0.4](https://crates.io/crates/ptree/0.4.0) (no newer version yet). However, it looks like that other warning doesn't cause clippy to return an error status code (probably a feature as it doesn't affect our code and will only become an issue in the future). So this trivial change is already enough.