### PR TITLE
Force you to run butido from the top-level git path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,10 +101,10 @@ async fn main() -> Result<()> {
     let app = cli::cli();
     let cli = app.get_matches();
 
-    let repo = git2::Repository::discover(PathBuf::from("."))
+    let repo = git2::Repository::open(PathBuf::from("."))
         .map_err(|e| match e.code() {
             git2::ErrorCode::NotFound => {
-                eprintln!("Butido must be executed within the package repository");
+                eprintln!("Butido must be executed in the top-level of the git repository");
                 std::process::exit(1)
             },
             _ => Error::from(e),


### PR DESCRIPTION
Running it from subdirectories gives out misleading error messages. For example:
```
$ butido source download git =2.39.3
Error: Loading the repository

Caused by:
    0: Reading file from filesystem: bash/5.0/pkg.toml
    1: No such file or directory (os error 2)
```

Fixes #170

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
