### PR TITLE
Disable automatic dependabot rebasing to avoid cancelling bors merges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,9 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 30
+  rebase-strategy: "disabled"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: monthly
+  rebase-strategy: "disabled"


### PR DESCRIPTION
The default rebase strategy ("auto") repeatedly caused the following issue in the past: We instructed the bors bot to merge multiple PRs at once by simultaneously commenting "bors merge" on the PRs. Unfortunately this doesn't work that well and the PRs often land in two or more batches (a bors-ng shortcoming). As a result, bors will only merge a subset of the PRs (the ones from the first batch) via an octopus merge, update the target branch, and then continue with the rest of the PRs / next batches. This is already undesirable but the bigger issue is that dependabot will trigger an automatic rebase when the target branch is updated. This rebase is usually unnecessary, as there would've been no conflict, and causes bors to cancel the merge due to the force-update of the branch/PR by dependabot (this makes sense for security reasons).

Therefore, dependabot should not perform those unnecessary rebases so that bors won't have to cancel the merges.

From the rebase-strategy documentation [0]:
> When rebase-strategy is set to auto, Dependabot attempts to rebase
> pull requests in the following cases:
> - When you use Dependabot version updates, for any open Dependabot
>   pull request when your schedule runs.
> - When you reopen a closed Dependabot pull request.
> - When you change the value of target-branch in the Dependabot
>   configuration file. For more information about this field, see
>   "target-branch."
> - When Dependabot detects that a Dependabot pull request is in
>   conflict after a recent push to the target branch.

However, e.g. #173 could've been merged without any conflicts that would require a rebase (or rather a new update attempt by dependabot as a rebase would trigger the same conflicts):
```console
$ git reset --hard 2b70a0ab4e5f4f6401e7434bbdf7242f76a5c2b7
HEAD is now at 2b70a0a Merge #174
$ git merge --no-edit 4a6b16fac653f4f699ef6c8185bccffccc15c791
Auto-merging Cargo.lock
Merge made by the 'ort' strategy.
 Cargo.lock | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
$ git diff 3c61fe00d4fb426a8efb100924b1c73d45f571e8
```

It's possible that [1] ("bors bot added a commit that referenced this pull request") caused the dependabot rebase.

Anyway, to avoid these issues, it seems best to disable the automatic rebasing for now and manually trigger rebases via the `@dependabot rebase` command instead.
Having to manually rebase PRs also comes with drawbacks but should currently work better (since I don't recall that a dependabot rebase was actually required so far).

Signed-off-by: Michael Weiss <michael.weiss@atos.net>

[0]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy
[1]: https://github.com/science-computing/butido/pull/173#ref-commit-5bd14c1

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
