### PR TITLE
Improve the version output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,23 +23,27 @@ use tracing::{debug, error};
 pub const IDENT_DEPENDENCY_TYPE_BUILD: &str = "build";
 pub const IDENT_DEPENDENCY_TYPE_RUNTIME: &str = "runtime";
 
-pub const VERSION: &str = formatcp!("{}\nGit SHA:\t\t{}\nBuild Timestamp:\t{}\nCargo Profile:\t\t{}",
-        env!("VERGEN_GIT_SEMVER"),
-        env!("VERGEN_GIT_SHA"),
-        env!("VERGEN_BUILD_TIMESTAMP"),
-        env!("VERGEN_CARGO_PROFILE"));
+pub const VERSION: &str = formatcp!("{}", env!("VERGEN_GIT_SEMVER"));
 
 pub fn cli<'a>() -> App<'a> {
     App::new("butido")
         .author(crate_authors!())
         .version(VERSION)
+        .disable_version_flag(true)
         .about("Generic Build Orchestration System for building linux packages with docker")
-
         .after_help(indoc::indoc!(r#"
             The following environment variables can be passed to butido:
 
                 RUST_LOG - to enable logging, for exact usage see the rust cookbook
         "#))
+
+        .arg(Arg::new("version")
+            .required(false)
+            .multiple(false)
+            .short('V')
+            .long("version")
+            .help("Detailed version output with build information")
+        )
 
         .arg(Arg::new("hide_bars")
             .required(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,15 @@ mod util;
 use crate::config::*;
 use crate::repository::Repository;
 use crate::util::progress::ProgressBars;
+use indoc::concatdoc;
+
+pub const VERSION_LONG: &str = concatdoc!{"
+    butido ", env!("VERGEN_GIT_SEMVER"), "
+    Git SHA:              ", env!("VERGEN_GIT_SHA"), "
+    Git Commit Timestamp: ", env!("VERGEN_GIT_COMMIT_TIMESTAMP"), "
+    Build Timestamp:      ", env!("VERGEN_BUILD_TIMESTAMP"), "
+    Cargo Profile:        ", env!("VERGEN_CARGO_PROFILE")
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -100,6 +109,12 @@ async fn main() -> Result<()> {
 
     let app = cli::cli();
     let cli = app.get_matches();
+
+    // check if the version flag is set
+    if cli.is_present("version") {
+        println!("{}", VERSION_LONG);
+        std::process::exit(0);
+    }
 
     let repo = git2::Repository::open(PathBuf::from("."))
         .map_err(|e| match e.code() {


### PR DESCRIPTION
The long version output was printed with the butido help output making it needlessly verbose.

Add the git commit timestamp to the version output.

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
