### PR TITLE
Fix the `images` table in two example TOML config files

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -154,7 +154,7 @@ available_phases = [ "unpack", "patch", "configure", "build", "fixup", "pack" ]
 # Images which can be used to build
 # images not listed here are automatically rejected
 images = [
-    { name = "debian:bullseye", shortname = "deb11" },
+    { name = "debian:bullseye", short_name = "deb11" },
 ]
 
 #

--- a/examples/packages/repo/config.toml
+++ b/examples/packages/repo/config.toml
@@ -38,7 +38,7 @@ available_phases = [
 # Images which can be used to build
 # images not listed here are automatically rejected
 images = [
-    { name = "debian:bullseye", shortname = "deb11" },
+    { name = "debian:bullseye", short_name = "deb11" },
 ]
 verify_images_present = true
 


### PR DESCRIPTION
This fixes a mistake in 108eecc. I updated that commit locally (didn't notice it right away as I renamed `shortname` to `short_name`) but forgot to re-push my local changes to GitHub (so I got surprised by a merge conflict when I rebased my local branch) :(
(Would be nice if we could validate the example config files via tests/CI but could be difficult as they aren't complete.)

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
