### PR TITLE
Get the supported shells for the generate-completions command from clap

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,7 +124,7 @@ pub fn cli<'a>() -> App<'a> {
             .version(VERSION)
             .about("Generate and print commandline completions")
             .arg(Arg::new("shell")
-                .possible_values(["bash", "elvish", "fish", "zsh"])
+                .value_parser(clap::value_parser!(clap_complete::Shell))
                 .default_value("bash")
                 .required(false)
                 .multiple(false)

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,21 +287,15 @@ async fn main() -> Result<()> {
 
 fn generate_completions(matches: &ArgMatches) {
     use clap_complete::generate;
-    use clap_complete::Generator;
     use clap_complete::Shell;
 
-    fn print_completions<G: Generator>(gen: G, cmd: &mut clap::Command) {
-        generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+    fn print_completions(shell: Shell, cmd: &mut clap::Command) {
+        eprintln!("Generating shell completions for {shell}...");
+        generate(shell, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
     }
 
-    let generator = match matches.value_of("shell").unwrap() { // unwrap safe by clap
-        "bash"   => Shell::Bash,
-        "elvish" => Shell::Elvish,
-        "fish"   => Shell::Fish,
-        "zsh"    => Shell::Zsh,
-        _ => unreachable!(),
-    };
-
-    eprintln!("Generating shell completions for {generator}...");
-    print_completions(generator, &mut cli::cli());
+    // src/cli.rs enforces that `shell` is set to a valid `Shell` so this is always true:
+    if let Some(shell) = matches.get_one::<Shell>("shell").copied() {
+        print_completions(shell, &mut cli::cli());
+    }
 }


### PR DESCRIPTION
This ensures that our hard coded shell values will not diverge from what clap_complete supports.
The new implementation is based on the example from the documentation: https://docs.rs/clap_complete/3.2.5/clap_complete/index.html

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

Examples:
```console
$ butido generate-completions > /dev/null
Generating shell completions for bash...
$ butido generate-completions zsh > /dev/null
Generating shell completions for zsh...
$ butido generate-completions fishh > /dev/null
error: "fishh" isn't a valid value for '<shell>'
        [possible values: bash, elvish, fish, powershell, zsh]

        Did you mean "fish"?

For more information try --help
```