### PR TITLE
Update and extend the author information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,11 @@
 name = "butido"
 version = "0.4.0"
 authors = [
-           "Christoph Prokop <christoph.prokop@atos.net>",
-           "Matthias Beyer <mail@beyermatthias.de>",
-          ]
+  # Only for the current/active maintainers (sorted alphabetically by the surname)
+  # All other authors are listed in the "Authors" section of README.md
+  "Nico Steinle <nico.steinle@atos.net>", # @ammernico
+  "Michael Weiss <michael.weiss@atos.net>", # @primeos-work
+]
 edition = "2021"
 rust-version = "1.64.0" # MSRV
 license = "EPL-2.0"

--- a/README.md
+++ b/README.md
@@ -91,9 +91,18 @@ cd /tmp/butido-test-repo
 | tree        | The tree structure that is computed before a packages is built to find out all (transitive) dependencies         |
 
 
+# Authors
+
+<!-- Note: The author lists should be sorted alphabetically by surname. -->
+- Original author: Matthias Beyer <mail@beyermatthias.de> @matthiasbeyer
+- Active maintainers: See `authors` in Cargo.toml
+- Passive maintainers
+  - Erdmut Pfeifer <erdmut.pfeifer@atos.net> @ErdmutPfeifer
+  - Christoph Prokop <christoph.prokop@atos.net> @christophprokop
+
+
 # License
 
 butido was developed for science+computing ag (an Atos company).
 
 License: EPL-2.0
-


### PR DESCRIPTION
The authorship information was a bit outdated.

I decided to differentiate between the original author (fixed) and active/passive maintainers.

All maintainers have commit access to the main repository but active maintainers work on / develop butido while the passive maintainers only handle GitHub PRs/issues.

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>

Please consider this an RFC and let me know if this is a good idea or not / what should be changed.
**This must not be merged before everyone agreed to it.**
I included the GitHub handles for convenience but we could also drop them.

@matthiasbeyer let me know if you'd like to remain in `authors` of `Cargo.toml` - you're the original author so this would be absolutely fine! I leave this up to you and I have no preference here. I'm not sure if there are any conventions for the format. The [documentation/specification](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field) states that "The exact meaning is open to interpretation — it may list the original or primary authors, current maintainers, or owners of the package".