### PR TITLE
Change the default log level from info to warn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2021,15 @@ checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -2757,10 +2775,14 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ zeroize = ">=1.3.0, <1.6.0"
 encoding_rs = ">=0.8.0, <=0.8.32"
 const_format = "0.2"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 toml = "0.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,10 @@ async fn main() -> Result<()> {
         homepage: "atos.net/de/deutschland/sc".into(),
     });
 
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt::fmt()
+        .with_max_level(tracing::Level::WARN)
+        .with_env_filter(tracing_subscriber::filter::EnvFilter::from_default_env())
+        .init();
     debug!("Debugging enabled");
 
     let app = cli::cli();


### PR DESCRIPTION
In ff5666c, we switched from env_logger to tracing. We later noticed that, as a side effect, the default log level changed from error [0] to info [1]. The info log level is too verbose by default but warnings might be useful or even important so we decided to explicitly setting the log level to warn.
The `EnvFilter` is required so that the `RUST_LOG` environment variable is still considered [2].

Fix #191.

Co-authored-by: Nico Steinle <nico.steinle@atos.net>
Signed-off-by: Nico Steinle <nico.steinle@atos.net>
Signed-off-by: Michael Weiss <michael.weiss@atos.net>

[0]: https://docs.rs/env_logger/0.10.0/env_logger/#enabling-logging
[1]: https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/fmt/struct.Subscriber.html#associatedconstant.DEFAULT_MAX_LEVEL
[2]: https://docs.rs/tracing-subscriber/0.3.16/tracing_subscriber/fmt/struct.SubscriberBuilder.html#method.with_max_level

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
