### PR TITLE
Update openssl{,-sys} to fix three security issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1627,9 +1627,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",


### PR DESCRIPTION
To fix the advisories check from cargo-deny. It failed due to the following three security issues:
- RUSTSEC-2023-0022: `openssl` `X509NameBuilder::build` returned object is not thread safe [0]
- RUSTSEC-2023-0023: `openssl` `SubjectAlternativeName` and `ExtendedKeyUsage::other` allow arbitrary file read [1]
- RUSTSEC-2023-0024: `openssl` `X509Extension::new` and `X509Extension::new_nid` null pointer dereference [2]

[0]: https://rustsec.org/advisories/RUSTSEC-2023-0022
[1]: https://rustsec.org/advisories/RUSTSEC-2023-0023
[2]: https://rustsec.org/advisories/RUSTSEC-2023-0024

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
