### PR TITLE
Fixed typo of rand version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ walkdir        = "2"
 which          = "4"
 xdg            = "2"
 
-# Hard-code rand to 0.4.4
+# Hard-code rand to 0.4.3
 #
 # Reason for this is this dependency chain:
 # diesel -> uuid (0.6) -> rand (0.4)


### PR DESCRIPTION
The correct version used is 0.4.3 but the comment stated 0.4.4. This patch fixes it.

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
