### PR TITLE
Improve the handling of multiple release stores

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -171,12 +171,13 @@ pub async fn build(
             let bar_release_loading = progressbars.bar()?;
 
             let p = config.releases_directory().join(storename);
-            debug!("Loading release directory: {}", p.display());
-            let r = ReleaseStore::load(StoreRoot::new(p)?, &bar_release_loading);
+            let p_str = p.to_string_lossy();
+            debug!("Loading release directory: {}", p_str);
+            let r = ReleaseStore::load(StoreRoot::new(p.clone())?, &bar_release_loading);
             if r.is_ok() {
-                bar_release_loading.finish_with_message("Loaded releases successfully");
+                bar_release_loading.finish_with_message(format!("Loaded releases in {p_str} successfully"));
             } else {
-                bar_release_loading.finish_with_message("Failed to load releases");
+                bar_release_loading.finish_with_message(format!("Failed to load releases in {p_str}"));
             }
             r.map(Arc::new)
         })

--- a/src/commands/find_artifact.rs
+++ b/src/commands/find_artifact.rs
@@ -64,12 +64,13 @@ pub async fn find_artifact(matches: &ArgMatches, config: &Configuration, progres
             let bar_release_loading = progressbars.bar()?;
 
             let p = config.releases_directory().join(storename);
-            debug!("Loading release directory: {}", p.display());
-            let r = ReleaseStore::load(StoreRoot::new(p)?, &bar_release_loading);
+            let p_str = p.to_string_lossy();
+            debug!("Loading release directory: {}", p_str);
+            let r = ReleaseStore::load(StoreRoot::new(p.clone())?, &bar_release_loading);
             if r.is_ok() {
-                bar_release_loading.finish_with_message("Loaded releases successfully");
+                bar_release_loading.finish_with_message(format!("Loaded releases in {p_str} successfully"));
             } else {
-                bar_release_loading.finish_with_message("Failed to load releases");
+                bar_release_loading.finish_with_message(format!("Failed to load releases in {p_str}"));
             }
 
             r.map(Arc::new)

--- a/src/filestore/path.rs
+++ b/src/filestore/path.rs
@@ -31,9 +31,20 @@ impl StoreRoot {
         if root.is_absolute() {
             if root.is_dir() {
                 Ok(StoreRoot(root))
+            } else if root.parent().map(Path::is_dir).unwrap_or(false) {
+                tracing::info!(
+                    "Creating a missing release store directory: {}",
+                    root.display()
+                );
+                std::fs::create_dir(&root)
+                    .with_context(|| anyhow!(
+                        "Couldn't automatically create the following release store directory: {}",
+                        root.display()
+                    ))?;
+                Ok(StoreRoot(root))
             } else {
                 Err(anyhow!(
-                    "StoreRoot path does not point to directory: {}",
+                    "The following StoreRoot path does not point to a directory: {}",
                     root.display()
                 ))
             }


### PR DESCRIPTION
Try to automatically create missing release stores and include the full paths in the output when loading them.

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
