### PR TITLE
Stop pinning zeroize as it isn't required anymore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,6 @@ dependencies = [
  "walkdir",
  "which",
  "xdg",
- "zeroize",
 ]
 
 [[package]]
@@ -3188,6 +3187,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,10 +98,6 @@ rand = "=0.4.3"
 # See https://github.com/bitvecto-rs/bitvec/issues/105#issuecomment-778570981
 funty = "=1.1.0"
 
-# Pin, because dialoguer pulls it in, but 1.4.x and newer has MSRV 1.51.0. With
-# the pin here, we enforce the build to not use 1.4.0 or newer.
-zeroize = ">=1.3.0, <1.6.0"
-
 # In 0.8.30 of encoding_rs, they messed up the license information in the crate
 # metadata. Thus, `cargo deny check licenses` fails.
 # This is not a direct dependency of ours, so we need to make sure that the

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ use logcrate::error;
 use rand as _; // Required to make lints happy
 use aquamarine as _; // doc-helper crate
 use funty as _; // doc-helper crate
-use zeroize as _; // Required to make lints happy
 use encoding_rs as _; // Required to make lints happy
 
 mod cli;


### PR DESCRIPTION
This was done in 3ae3899 as a temporary change to keep the MSRV lower but isn't required anymore for quite a while (our current MSRV is 1.64.0 and that comment is outdated since d3487fc).

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
