### PR TITLE
Cleanup old Cargo.toml dependencies / version constraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,6 @@ dependencies = [
  "dialoguer",
  "diesel",
  "diesel_migrations",
- "encoding_rs",
  "filters",
  "funty",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "filters",
- "funty",
  "futures",
  "getset",
  "git2",
@@ -775,12 +774,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,6 @@ dependencies = [
  "walkdir",
  "which",
  "xdg",
- "zeroize",
 ]
 
 [[package]]
@@ -3188,6 +3187,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,10 +98,6 @@ rand = "=0.4.3"
 # See https://github.com/bitvecto-rs/bitvec/issues/105#issuecomment-778570981
 funty = "=1.1.0"
 
-# Pin, because dialoguer pulls it in, but 1.4.x and newer has MSRV 1.51.0. With
-# the pin here, we enforce the build to not use 1.4.0 or newer.
-zeroize = ">=1.3.0, <1.6.0"
-
 # In 0.8.30 of encoding_rs, they messed up the license information in the crate
 # metadata. Thus, `cargo deny check licenses` fails.
 # This is not a direct dependency of ours, so we need to make sure that the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,6 @@ xdg            = "2"
 # Upstream issue: https://github.com/rust-random/rand/issues/1071
 rand = "=0.4.3"
 
-# See https://github.com/bitvecto-rs/bitvec/issues/105#issuecomment-778570981
-funty = "=1.1.0"
-
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,12 +98,6 @@ rand = "=0.4.3"
 # See https://github.com/bitvecto-rs/bitvec/issues/105#issuecomment-778570981
 funty = "=1.1.0"
 
-# In 0.8.30 of encoding_rs, they messed up the license information in the crate
-# metadata. Thus, `cargo deny check licenses` fails.
-# This is not a direct dependency of ours, so we need to make sure that the
-# dependency is kept below 0.8.30.
-# Make sure to remove this constraint as soon as possible.
-encoding_rs = ">=0.8.0, <=0.8.32"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ use logcrate::error;
 use rand as _; // Required to make lints happy
 use aquamarine as _; // doc-helper crate
 use funty as _; // doc-helper crate
-use encoding_rs as _; // Required to make lints happy
 
 mod cli;
 mod commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,6 @@ use logcrate::error;
 use rand as _; // Required to make lints happy
 use aquamarine as _; // doc-helper crate
 use funty as _; // doc-helper crate
-use zeroize as _; // Required to make lints happy
 use encoding_rs as _; // Required to make lints happy
 
 mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,6 @@ use logcrate::debug;
 use logcrate::error;
 use rand as _; // Required to make lints happy
 use aquamarine as _; // doc-helper crate
-use funty as _; // doc-helper crate
 
 mod cli;
 mod commands;


### PR DESCRIPTION
We had a few old and outdated direct dependencies in Cargo.toml.
The details are described in the individual commit messages.
<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
