### PR TITLE
Stop checking for a clean working tree

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -69,7 +69,6 @@ pub async fn build(
     let git_repo = git2::Repository::open(repo_path)
         .with_context(|| anyhow!("Opening repository at {}", repo_path.display()))?;
 
-    crate::ui::package_repo_cleanness_check(&git_repo)?;
     let now = chrono::offset::Local::now().naive_local();
 
     let shebang = Shebang::from({

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,28 +16,12 @@ use std::path::PathBuf;
 use anyhow::Result;
 use anyhow::anyhow;
 use itertools::Itertools;
-use tracing::error;
 
 use crate::config::Configuration;
 use crate::package::Script;
 
 mod package;
 pub use crate::ui::package::*;
-
-pub fn package_repo_cleanness_check(repo: &git2::Repository) -> Result<()> {
-    if !crate::util::git::repo_is_clean(repo)? {
-        error!(
-            "Repository not clean, refusing to go on: {}",
-            repo.path().display()
-        );
-        Err(anyhow!(
-            "Repository not clean, refusing to go on: {}",
-            repo.path().display()
-        ))
-    } else {
-        Ok(())
-    }
-}
 
 pub fn script_to_printable(
     script: &Script,

--- a/src/util/git.rs
+++ b/src/util/git.rs
@@ -10,21 +10,9 @@
 
 use anyhow::anyhow;
 use anyhow::Context;
-use anyhow::Error;
 use anyhow::Result;
 use git2::Repository;
 use tracing::trace;
-
-pub fn repo_is_clean(r: &Repository) -> Result<bool> {
-    r.diff_index_to_workdir(None, None)
-        .and_then(|d| d.stats())
-        .map_err(Error::from)
-        .map(|st| {
-            trace!("Repo stats: {:?}", st);
-            trace!("Repo state: {:?}", r.state());
-            st.files_changed() == 0 && r.state() == git2::RepositoryState::Clean
-        })
-}
 
 pub fn get_repo_head_commit_hash(r: &Repository) -> Result<String> {
     let s = r


### PR DESCRIPTION
When the packages repository has uncommitted changes in tracked files, butido refused to build with it. Raising:

`Repository not clean, refusing to go on:`

Checking for a clean working tree is somewhat unnecessary and resulted in some users not tracking files at all.

<details>
<!-- Any extra information below the details tag line above won't be included in the merge commit from bors (useful for questions, notes, etc.). -->
<!-- Also: Please read CONTRIBUTING.md first and consider the checklist. -->
</details>
