### PR TITLE
Format the codebase via rustfmt

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -3,6 +3,23 @@ on: [push, pull_request, merge_group]
 name: Cargo
 
 jobs:
+  fmt:
+    name: Fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3.5.3
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: 1.65.0 # MSRV
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt --check
+
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -112,6 +129,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs:
+      - fmt
       - check
       - test
       - deny

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,14 @@
 use anyhow::Result;
-use vergen::EmitBuilder;
 use std::error::Error;
-
+use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
     EmitBuilder::builder()
-          .build_timestamp()
-          .cargo_debug()
-          .git_sha(false)
-          .git_commit_timestamp()
-          .git_describe(true, true, None)
-          .emit()?;
+        .build_timestamp()
+        .cargo_debug()
+        .git_sha(false)
+        .git_commit_timestamp()
+        .git_describe(true, true, None)
+        .emit()?;
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,10 +12,10 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use clap::crate_authors;
-use clap::Command;
 use clap::Arg;
 use clap::ArgAction;
 use clap::ArgGroup;
+use clap::Command;
 
 use tracing::{debug, error};
 
@@ -1246,7 +1246,8 @@ fn arg_older_than_date(about: &str) -> Arg {
         .long("older-than")
         .value_name("DATE")
         .help(about.to_owned())
-        .long_help(r#"
+        .long_help(
+            r#"
             DATE can be a freeform date, for example '2h'
             It can also be a exact date: '2020-01-01 00:12:45'
             If the hour-minute-second part is omitted, " 00:00:00" is appended automatically.
@@ -1264,7 +1265,8 @@ fn arg_older_than_date(about: &str) -> Arg {
                 months, month, M -- defined as 30.44 days
                 years, year, y -- defined as 365.25 days
 
-        "#)
+        "#,
+        )
         .value_parser(parse_date_from_string)
 }
 
@@ -1274,7 +1276,8 @@ fn arg_newer_than_date(about: &str) -> Arg {
         .long("newer-than")
         .value_name("DATE")
         .help(about.to_owned())
-        .long_help(r#"
+        .long_help(
+            r#"
             DATE can be a freeform date, for example '2h'
             It can also be a exact date: '2020-01-01 00:12:45'
             If the hour-minute-second part is omitted, " 00:00:00" is appended automatically.
@@ -1292,7 +1295,8 @@ fn arg_newer_than_date(about: &str) -> Arg {
                 months, month, M -- defined as 30.44 days
                 years, year, y -- defined as 365.25 days
 
-        "#)
+        "#,
+        )
         .value_parser(parse_date_from_string)
 }
 
@@ -1315,11 +1319,15 @@ fn parse_date_from_string(s: &str) -> std::result::Result<String, String> {
 }
 
 fn parse_usize(s: &str) -> std::result::Result<String, String> {
-    usize::from_str(s) .map_err(|e| e.to_string()).map(|_| s.to_owned())
+    usize::from_str(s)
+        .map_err(|e| e.to_string())
+        .map(|_| s.to_owned())
 }
 
 fn parse_u64(s: &str) -> std::result::Result<String, String> {
-    u64::from_str(s).map_err(|e| e.to_string()).map(|_| s.to_owned())
+    u64::from_str(s)
+        .map_err(|e| e.to_string())
+        .map(|_| s.to_owned())
 }
 
 #[cfg(test)]

--- a/src/commands/find_pkg.rs
+++ b/src/commands/find_pkg.rs
@@ -15,9 +15,9 @@ use std::convert::TryFrom;
 use anyhow::Context;
 use anyhow::Result;
 use clap::ArgMatches;
-use tracing::trace;
 use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
+use tracing::trace;
 
 use crate::config::Configuration;
 use crate::package::PackageVersionConstraint;

--- a/src/commands/tree_of.rs
+++ b/src/commands/tree_of.rs
@@ -17,19 +17,16 @@ use anyhow::Result;
 use clap::ArgMatches;
 use resiter::AndThen;
 
+use crate::package::condition::ConditionData;
 use crate::package::Dag;
 use crate::package::PackageName;
 use crate::package::PackageVersionConstraint;
-use crate::package::condition::ConditionData;
 use crate::repository::Repository;
-use crate::util::EnvironmentVariableName;
 use crate::util::docker::ImageName;
+use crate::util::EnvironmentVariableName;
 
 /// Implementation of the "tree_of" subcommand
-pub async fn tree_of(
-    matches: &ArgMatches,
-    repo: Repository,
-) -> Result<()> {
+pub async fn tree_of(matches: &ArgMatches, repo: Repository) -> Result<()> {
     let pname = matches
         .get_one::<String>("package_name")
         .map(|s| s.to_owned())

--- a/src/commands/util.rs
+++ b/src/commands/util.rs
@@ -10,19 +10,19 @@
 
 //! Utility module for subcommand implementation helpers
 
-use std::io::Write;
 use std::fmt::Display;
+use std::io::Write;
 use std::path::Path;
 
+use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
-use anyhow::anyhow;
 use clap::ArgMatches;
 use itertools::Itertools;
-use tracing::{error, info, trace};
 use regex::Regex;
 use tokio_stream::StreamExt;
+use tracing::{error, info, trace};
 
 use crate::config::*;
 use crate::package::Package;
@@ -183,7 +183,7 @@ pub fn display_data<D: Display>(
     csv: bool,
 ) -> Result<()> {
     if data.is_empty() {
-        return Ok(())
+        return Ok(());
     }
 
     if csv {
@@ -204,9 +204,10 @@ pub fn display_data<D: Display>(
             .and_then(|text| writeln!(lock, "{text}").map_err(Error::from))
     } else if atty::is(atty::Stream::Stdout) {
         let mut ascii_table = ascii_table::AsciiTable::default();
-        ascii_table.set_max_width(terminal_size::terminal_size()
-            .map(|tpl| tpl.0 .0 as usize) // an ugly interface indeed!
-            .unwrap_or(80)
+        ascii_table.set_max_width(
+            terminal_size::terminal_size()
+                .map(|tpl| tpl.0 .0 as usize) // an ugly interface indeed!
+                .unwrap_or(80),
         );
 
         headers.into_iter().enumerate().for_each(|(i, c)| {
@@ -225,8 +226,12 @@ pub fn display_data<D: Display>(
     }
 }
 
-pub fn get_date_filter(name: &str, matches: &ArgMatches) -> Result<Option<chrono::DateTime::<chrono::Local>>> {
-    matches.get_one::<String>(name)
+pub fn get_date_filter(
+    name: &str,
+    matches: &ArgMatches,
+) -> Result<Option<chrono::DateTime<chrono::Local>>> {
+    matches
+        .get_one::<String>(name)
         .map(|s| {
             trace!("Parsing duration: '{}'", s);
             humantime::parse_duration(s)
@@ -257,4 +262,3 @@ pub fn get_date_filter(name: &str, matches: &ArgMatches) -> Result<Option<chrono
         })
         .transpose()
 }
-

--- a/src/commands/what_depends.rs
+++ b/src/commands/what_depends.rs
@@ -16,9 +16,9 @@ use anyhow::Result;
 use clap::ArgMatches;
 use futures::stream::StreamExt;
 use futures::stream::TryStreamExt;
-use tracing::trace;
 use resiter::Filter;
 use resiter::Map;
+use tracing::trace;
 
 use crate::commands::util::getbool;
 use crate::config::*;
@@ -87,7 +87,8 @@ pub async fn what_depends(
         .filter_ok(|(b, _)| *b)
         .map_ok(|tpl| tpl.1)
         .inspect(|pkg| trace!("Found package: {:?}", pkg))
-        .map_ok(|p| { // poor mans enumerate_ok()
+        .map_ok(|p| {
+            // poor mans enumerate_ok()
             i += 1;
             p.prepare_print(config, &flags, &hb, i)
         });

--- a/src/config/endpoint_config.rs
+++ b/src/config/endpoint_config.rs
@@ -64,4 +64,3 @@ pub enum EndpointType {
     #[serde(rename = "http")]
     Http,
 }
-

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -24,7 +24,6 @@ use crate::package::PhaseName;
 /// The configuration that is loaded from the filesystem
 #[derive(Debug, Getters, Deserialize)]
 pub struct NotValidatedConfiguration {
-
     /// Compatibility setting
     ///
     /// If the version of butido is (semver) incompatible to this setting in the configuration,
@@ -177,7 +176,9 @@ impl NotValidatedConfiguration {
         }
 
         if self.release_stores.is_empty() {
-            return Err(anyhow!("You need at least one release store in 'release_stores'"))
+            return Err(anyhow!(
+                "You need at least one release store in 'release_stores'"
+            ));
         }
 
         // Error if source_cache_root is not a directory

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,10 +8,9 @@
 // SPDX-License-Identifier: EPL-2.0
 //
 
-
 /// The path to the directory inside the container where the inputs for the script run are copied
 /// to.
-pub const INPUTS_DIR_PATH: &str  = "/inputs";
+pub const INPUTS_DIR_PATH: &str = "/inputs";
 
 /// The path to the directory inside the container where the outputs of a compile job must be
 /// located after the script was run
@@ -21,5 +20,4 @@ pub const OUTPUTS_DIR_NAME: &str = "outputs";
 pub const PATCH_DIR_PATH: &str = "/patches";
 
 /// The path where the script that is executed inside the container is copied to.
-pub const SCRIPT_PATH: &str      = "/script";
-
+pub const SCRIPT_PATH: &str = "/script";

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -43,7 +43,9 @@ pub struct DbConnectionConfig<'a> {
 
 impl<'a> std::fmt::Debug for DbConnectionConfig<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "postgres://{user}:PASSWORD@{host}:{port}/{name}?connect_timeout={timeout}",
+        write!(
+            f,
+            "postgres://{user}:PASSWORD@{host}:{port}/{name}?connect_timeout={timeout}",
             host = self.database_host,
             port = self.database_port,
             user = self.database_user,
@@ -56,21 +58,29 @@ impl<'a> std::fmt::Debug for DbConnectionConfig<'a> {
 impl<'a> DbConnectionConfig<'a> {
     pub fn parse(config: &'a Configuration, cli: &'a ArgMatches) -> Result<DbConnectionConfig<'a>> {
         Ok(DbConnectionConfig {
-            database_host: cli.get_one::<String>("database_host").unwrap_or_else(|| config.database_host()),
+            database_host: cli
+                .get_one::<String>("database_host")
+                .unwrap_or_else(|| config.database_host()),
             database_port: {
                 cli.get_one::<String>("database_port")
                     .map(|s| s.parse::<u16>())
                     .transpose()?
                     .unwrap_or_else(|| *config.database_port())
             },
-            database_user: cli.get_one::<String>("database_user").unwrap_or_else(|| config.database_user()),
-            database_password: cli.get_one::<String>("database_password").unwrap_or_else(|| config.database_password()),
-            database_name: cli.get_one::<String>("database_name").unwrap_or_else(|| config.database_name()),
+            database_user: cli
+                .get_one::<String>("database_user")
+                .unwrap_or_else(|| config.database_user()),
+            database_password: cli
+                .get_one::<String>("database_password")
+                .unwrap_or_else(|| config.database_password()),
+            database_name: cli
+                .get_one::<String>("database_name")
+                .unwrap_or_else(|| config.database_name()),
             database_connection_timeout: {
                 cli.get_one::<String>("database_connection_timeout")
                     .map(|s| s.parse::<u16>())
                     .transpose()?
-                    .unwrap_or_else( || {
+                    .unwrap_or_else(|| {
                         // hardcoded default of 30 seconds database timeout
                         config.database_connection_timeout().unwrap_or(30)
                     })
@@ -96,13 +106,14 @@ impl<'a> DbConnectionConfig<'a> {
     }
 
     pub fn establish_pool(self) -> Result<Pool<ConnectionManager<PgConnection>>> {
-        debug!("Trying to create a connection pool for database: {:?}", self);
+        debug!(
+            "Trying to create a connection pool for database: {:?}",
+            self
+        );
         let manager = ConnectionManager::<PgConnection>::new(self.get_database_uri());
         Pool::builder()
             .min_idle(Some(1))
             .build(manager)
             .map_err(Error::from)
     }
-
 }
-

--- a/src/db/models/endpoint.rs
+++ b/src/db/models/endpoint.rs
@@ -30,8 +30,13 @@ struct NewEndpoint<'a> {
 }
 
 impl Endpoint {
-    pub fn create_or_fetch(database_connection: &mut PgConnection, ep_name: &EndpointName) -> Result<Endpoint> {
-        let new_ep = NewEndpoint { name: ep_name.as_ref() };
+    pub fn create_or_fetch(
+        database_connection: &mut PgConnection,
+        ep_name: &EndpointName,
+    ) -> Result<Endpoint> {
+        let new_ep = NewEndpoint {
+            name: ep_name.as_ref(),
+        };
 
         database_connection.transaction::<_, Error, _>(|conn| {
             diesel::insert_into(endpoints::table)
@@ -46,12 +51,21 @@ impl Endpoint {
         })
     }
 
-    pub fn fetch_for_job(database_connection: &mut PgConnection, j: &crate::db::models::Job) -> Result<Option<Endpoint>> {
+    pub fn fetch_for_job(
+        database_connection: &mut PgConnection,
+        j: &crate::db::models::Job,
+    ) -> Result<Option<Endpoint>> {
         Self::fetch_by_id(database_connection, j.endpoint_id)
     }
 
-    pub fn fetch_by_id(database_connection: &mut PgConnection, eid: i32) -> Result<Option<Endpoint>> {
-        match dsl::endpoints.filter(id.eq(eid)).first::<Endpoint>(database_connection) {
+    pub fn fetch_by_id(
+        database_connection: &mut PgConnection,
+        eid: i32,
+    ) -> Result<Option<Endpoint>> {
+        match dsl::endpoints
+            .filter(id.eq(eid))
+            .first::<Endpoint>(database_connection)
+        {
             Err(diesel::result::Error::NotFound) => Ok(None),
             Err(e) => Err(Error::from(e)),
             Ok(e) => Ok(Some(e)),

--- a/src/db/models/githash.rs
+++ b/src/db/models/githash.rs
@@ -30,7 +30,10 @@ struct NewGitHash<'a> {
 }
 
 impl GitHash {
-    pub fn create_or_fetch(database_connection: &mut PgConnection, githash: &str) -> Result<GitHash> {
+    pub fn create_or_fetch(
+        database_connection: &mut PgConnection,
+        githash: &str,
+    ) -> Result<GitHash> {
         let new_hash = NewGitHash { hash: githash };
 
         database_connection.transaction::<_, Error, _>(|conn| {

--- a/src/db/models/image.rs
+++ b/src/db/models/image.rs
@@ -51,12 +51,18 @@ impl Image {
         })
     }
 
-    pub fn fetch_for_job(database_connection: &mut PgConnection, j: &crate::db::models::Job) -> Result<Option<Image>> {
+    pub fn fetch_for_job(
+        database_connection: &mut PgConnection,
+        j: &crate::db::models::Job,
+    ) -> Result<Option<Image>> {
         Self::fetch_by_id(database_connection, j.image_id)
     }
 
     pub fn fetch_by_id(database_connection: &mut PgConnection, iid: i32) -> Result<Option<Image>> {
-        match dsl::images.filter(id.eq(iid)).first::<Image>(database_connection) {
+        match dsl::images
+            .filter(id.eq(iid))
+            .first::<Image>(database_connection)
+        {
             Err(diesel::result::Error::NotFound) => Ok(None),
             Err(e) => Err(Error::from(e)),
             Ok(i) => Ok(Some(i)),

--- a/src/db/models/job.rs
+++ b/src/db/models/job.rs
@@ -8,8 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 //
 
-use anyhow::Error;
 use anyhow::Context;
+use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
 use diesel::PgConnection;
@@ -81,12 +81,13 @@ impl Job {
             .values(&new_job)
             .on_conflict_do_nothing();
 
-        trace!("Query = {}", diesel::debug_query::<diesel::pg::Pg, _>(&query));
+        trace!(
+            "Query = {}",
+            diesel::debug_query::<diesel::pg::Pg, _>(&query)
+        );
 
         database_connection.transaction::<_, Error, _>(|conn| {
-            query
-                .execute(conn)
-                .context("Creating job in database")?;
+            query.execute(conn).context("Creating job in database")?;
 
             dsl::jobs
                 .filter(uuid.eq(job_uuid))
@@ -96,7 +97,10 @@ impl Job {
         })
     }
 
-    pub fn env(&self, database_connection: &mut PgConnection) -> Result<Vec<crate::db::models::EnvVar>> {
+    pub fn env(
+        &self,
+        database_connection: &mut PgConnection,
+    ) -> Result<Vec<crate::db::models::EnvVar>> {
         use crate::schema;
 
         schema::job_envs::table

--- a/src/db/models/package.rs
+++ b/src/db/models/package.rs
@@ -60,12 +60,21 @@ impl Package {
         })
     }
 
-    pub fn fetch_for_job(database_connection: &mut PgConnection, j: &crate::db::models::Job) -> Result<Option<Package>> {
+    pub fn fetch_for_job(
+        database_connection: &mut PgConnection,
+        j: &crate::db::models::Job,
+    ) -> Result<Option<Package>> {
         Self::fetch_by_id(database_connection, j.package_id)
     }
 
-    pub fn fetch_by_id(database_connection: &mut PgConnection, pid: i32) -> Result<Option<Package>> {
-        match dsl::packages.filter(id.eq(pid)).first::<Package>(database_connection) {
+    pub fn fetch_by_id(
+        database_connection: &mut PgConnection,
+        pid: i32,
+    ) -> Result<Option<Package>> {
+        match dsl::packages
+            .filter(id.eq(pid))
+            .first::<Package>(database_connection)
+        {
             Err(diesel::result::Error::NotFound) => Ok(None),
             Err(e) => Err(Error::from(e)),
             Ok(p) => Ok(Some(p)),

--- a/src/db/models/release_store.rs
+++ b/src/db/models/release_store.rs
@@ -16,8 +16,8 @@ use diesel::PgConnection;
 use diesel::QueryDsl;
 use diesel::RunQueryDsl;
 
-use crate::schema::release_stores;
 use crate::schema;
+use crate::schema::release_stores;
 
 #[derive(Debug, Identifiable, Queryable)]
 #[diesel(table_name = release_stores)]
@@ -29,14 +29,12 @@ pub struct ReleaseStore {
 #[derive(Insertable)]
 #[diesel(table_name = release_stores)]
 struct NewReleaseStore<'a> {
-    pub store_name : &'a str,
+    pub store_name: &'a str,
 }
 
 impl ReleaseStore {
     pub fn create(database_connection: &mut PgConnection, name: &str) -> Result<ReleaseStore> {
-        let new_relstore = NewReleaseStore {
-            store_name: name,
-        };
+        let new_relstore = NewReleaseStore { store_name: name };
 
         database_connection.transaction::<_, Error, _>(|conn| {
             diesel::insert_into(schema::release_stores::table)
@@ -51,4 +49,3 @@ impl ReleaseStore {
         })
     }
 }
-

--- a/src/db/models/submit.rs
+++ b/src/db/models/submit.rs
@@ -64,10 +64,8 @@ impl Submit {
         database_connection.transaction::<_, Error, _>(|conn| {
             diesel::insert_into(submits::table)
                 .values(&new_submit)
-
                 // required because if we re-use the staging store, we do not create a new UUID but re-use the old one
                 .on_conflict_do_nothing()
-
                 .execute(conn)
                 .context("Inserting new submit into submits table")?;
 
@@ -75,7 +73,10 @@ impl Submit {
         })
     }
 
-    pub fn with_id(database_connection: &mut PgConnection, submit_id: &::uuid::Uuid) -> Result<Submit> {
+    pub fn with_id(
+        database_connection: &mut PgConnection,
+        submit_id: &::uuid::Uuid,
+    ) -> Result<Submit> {
         dsl::submits
             .filter(submits::uuid.eq(submit_id))
             .first::<Submit>(database_connection)

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -18,4 +18,3 @@ mod configured;
 pub use configured::*;
 
 pub mod util;
-

--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -16,21 +16,21 @@ use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
 use colored::Colorize;
-use diesel::PgConnection;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;
+use diesel::PgConnection;
 use indicatif::ProgressBar;
 use itertools::Itertools;
-use tracing::trace;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::RwLock;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::RwLock;
+use tracing::trace;
 use uuid::Uuid;
 
 use crate::db::models as dbmodels;
 use crate::endpoint::Endpoint;
-use crate::endpoint::EndpointHandle;
 use crate::endpoint::EndpointConfiguration;
+use crate::endpoint::EndpointHandle;
 use crate::filestore::ArtifactPath;
 use crate::filestore::ReleaseStore;
 use crate::filestore::StagingStore;
@@ -74,7 +74,11 @@ impl EndpointScheduler {
     /// # Warning
     ///
     /// This function blocks as long as there is no free endpoint available!
-    pub async fn schedule_job(&self, job: RunnableJob, bar: indicatif::ProgressBar) -> Result<JobHandle> {
+    pub async fn schedule_job(
+        &self,
+        job: RunnableJob,
+        bar: indicatif::ProgressBar,
+    ) -> Result<JobHandle> {
         let endpoint = self.select_free_endpoint().await?;
 
         Ok(JobHandle {
@@ -94,13 +98,20 @@ impl EndpointScheduler {
             let ep = self
                 .endpoints
                 .iter()
-                .filter(|ep| { // filter out all running containers where the number of max jobs is reached
+                .filter(|ep| {
+                    // filter out all running containers where the number of max jobs is reached
                     let r = ep.running_jobs() < ep.num_max_jobs();
-                    trace!("Endpoint {} considered for scheduling job: {}", ep.name(), r);
+                    trace!(
+                        "Endpoint {} considered for scheduling job: {}",
+                        ep.name(),
+                        r
+                    );
                     r
                 })
                 .sorted_by(|ep1, ep2| {
-                    ep1.utilization().partial_cmp(&ep2.utilization()).unwrap_or(std::cmp::Ordering::Equal)
+                    ep1.utilization()
+                        .partial_cmp(&ep2.utilization())
+                        .unwrap_or(std::cmp::Ordering::Equal)
                 })
                 .next();
 
@@ -136,14 +147,26 @@ impl JobHandle {
         let (log_sender, log_receiver) = tokio::sync::mpsc::unbounded_channel::<LogItem>();
         let endpoint_uri = self.endpoint.uri().clone();
         let endpoint_name = self.endpoint.name().clone();
-        let endpoint = dbmodels::Endpoint::create_or_fetch(&mut self.db.get().unwrap(), self.endpoint.name())?;
-        let package = dbmodels::Package::create_or_fetch(&mut self.db.get().unwrap(), self.job.package())?;
-        let image = dbmodels::Image::create_or_fetch(&mut self.db.get().unwrap(), self.job.image())?;
+        let endpoint =
+            dbmodels::Endpoint::create_or_fetch(&mut self.db.get().unwrap(), self.endpoint.name())?;
+        let package =
+            dbmodels::Package::create_or_fetch(&mut self.db.get().unwrap(), self.job.package())?;
+        let image =
+            dbmodels::Image::create_or_fetch(&mut self.db.get().unwrap(), self.job.image())?;
         let envs = self.create_env_in_db()?;
         let job_id = *self.job.uuid();
-        trace!("Running on Job {} on Endpoint {}", job_id, self.endpoint.name());
-        let prepared_container = self.endpoint
-            .prepare_container(&self.job, self.staging_store.clone(), self.release_stores.clone())
+        trace!(
+            "Running on Job {} on Endpoint {}",
+            job_id,
+            self.endpoint.name()
+        );
+        let prepared_container = self
+            .endpoint
+            .prepare_container(
+                &self.job,
+                self.staging_store.clone(),
+                self.release_stores.clone(),
+            )
             .await?;
         let container_id = prepared_container.create_info().id.clone();
         let running_container = prepared_container
@@ -174,7 +197,8 @@ impl JobHandle {
         drop(self.bar);
 
         let (run_container, logres) = tokio::join!(running_container, logres);
-        let log = logres.with_context(|| anyhow!("Collecting logs for job on '{}'", endpoint_name))?;
+        let log =
+            logres.with_context(|| anyhow!("Collecting logs for job on '{}'", endpoint_name))?;
         let run_container = run_container
             .with_context(|| anyhow!("Running container {} failed", container_id))
             .with_context(|| {
@@ -202,8 +226,14 @@ impl JobHandle {
 
         trace!("DB: Job entry for job {} created: {}", job.uuid, job.id);
         for env in envs {
-            dbmodels::JobEnv::create(&mut self.db.get().unwrap(), &job, &env)
-                .with_context(|| format!("Creating Environment Variable mapping for Job: {}", job.uuid))?;
+            dbmodels::JobEnv::create(&mut self.db.get().unwrap(), &job, &env).with_context(
+                || {
+                    format!(
+                        "Creating Environment Variable mapping for Job: {}",
+                        job.uuid
+                    )
+                },
+            )?;
         }
 
         let res: crate::endpoint::FinalizedContainer = run_container
@@ -239,7 +269,7 @@ impl JobHandle {
             trace!("Error was returned from script");
             return Ok({
                 res.map(|_| vec![]) // to have the proper type, will never be executed
-             })
+            });
         }
 
         // Have to do it the ugly way here because of borrowing semantics
@@ -259,7 +289,13 @@ impl JobHandle {
     }
 
     /// Helper to create an error object with a nice message.
-    fn create_job_run_error(job_id: &Uuid, package_name: &str, package_version: &str, endpoint_uri: &str, container_id: &str) -> Error {
+    fn create_job_run_error(
+        job_id: &Uuid,
+        package_name: &str,
+        package_version: &str,
+        endpoint_uri: &str,
+        container_id: &str,
+    ) -> Error {
         anyhow!(indoc::formatdoc!(
             r#"Error while running job for {package_name} {package_version} with id:
 
@@ -276,9 +312,10 @@ impl JobHandle {
             job_id = job_id.to_string().red(),
             package_name = package_name.to_string().red(),
             package_version = package_version.to_string().red(),
-
-            docker_connect_string = format!("docker --host {endpoint_uri} exec -it {container_id} /bin/bash"
-            ).yellow().bold(),
+            docker_connect_string =
+                format!("docker --host {endpoint_uri} exec -it {container_id} /bin/bash")
+                    .yellow()
+                    .bold(),
         ))
     }
 
@@ -295,7 +332,9 @@ impl JobHandle {
                     .inspect(|(k, v)| {
                         trace!("Creating environment variable in database: {} = {}", k, v)
                     })
-                    .map(|(k, v)| dbmodels::EnvVar::create_or_fetch(&mut self.db.get().unwrap(), k, v))
+                    .map(|(k, v)| {
+                        dbmodels::EnvVar::create_or_fetch(&mut self.db.get().unwrap(), k, v)
+                    })
                     .collect::<Result<Vec<_>>>()
             })
             .transpose()?
@@ -310,7 +349,9 @@ impl JobHandle {
                     .inspect(|(k, v)| {
                         trace!("Creating environment variable in database: {} = {}", k, v)
                     })
-                    .map(|(k, v)| dbmodels::EnvVar::create_or_fetch(&mut self.db.get().unwrap(), k, v))
+                    .map(|(k, v)| {
+                        dbmodels::EnvVar::create_or_fetch(&mut self.db.get().unwrap(), k, v)
+                    })
             })
             .collect()
     }
@@ -335,7 +376,8 @@ impl<'a> LogReceiver<'a> {
         // Reserve a reasonable amount of elements.
         accu.reserve(4096);
 
-        let mut logfile = self.get_logfile()
+        let mut logfile = self
+            .get_logfile()
             .await
             .transpose()
             .context("Getting Logfile")?;
@@ -353,15 +395,16 @@ impl<'a> LogReceiver<'a> {
             // Timeout for receiving from the log receiver channel
             // This way we can update (`tick()`) the progress bar and show the user that things are
             // happening, even if there was no log output for several seconds.
-            let logitem = match tokio::time::timeout(timeout_duration, self.log_receiver.recv()).await {
-                Err(_ /* elapsed */) => {
-                    self.bar.tick(); // just ping the progressbar here
-                    continue
-                },
+            let logitem =
+                match tokio::time::timeout(timeout_duration, self.log_receiver.recv()).await {
+                    Err(_ /* elapsed */) => {
+                        self.bar.tick(); // just ping the progressbar here
+                        continue;
+                    }
 
-                Ok(None) => break, // if the log is empty, we're done
-                Ok(Some(logitem)) => logitem,
-            };
+                    Ok(None) => break, // if the log is empty, we're done
+                    Ok(Some(logitem)) => logitem,
+                };
 
             if let Some(lf) = logfile.as_mut() {
                 lf.write_all(logitem.display()?.to_string().as_bytes())
@@ -381,14 +424,23 @@ impl<'a> LogReceiver<'a> {
                     trace!("Setting bar phase to {}", phasename);
                     self.bar.set_message(format!(
                         "[{}/{} {} {} {}]: Phase: {}",
-                        self.endpoint_name, self.container_id_chrs, self.job.uuid(), self.package_name, self.package_version, phasename
+                        self.endpoint_name,
+                        self.container_id_chrs,
+                        self.job.uuid(),
+                        self.package_name,
+                        self.package_version,
+                        phasename
                     ));
                 }
                 LogItem::State(Ok(())) => {
                     trace!("Setting bar state to Ok");
                     self.bar.set_message(format!(
                         "[{}/{} {} {} {}]: State Ok",
-                        self.endpoint_name, self.container_id_chrs, self.job.uuid(), self.package_name, self.package_version
+                        self.endpoint_name,
+                        self.container_id_chrs,
+                        self.job.uuid(),
+                        self.package_name,
+                        self.package_version
                     ));
                     success = Some(true);
                 }
@@ -396,7 +448,12 @@ impl<'a> LogReceiver<'a> {
                     trace!("Setting bar state to Err: {}", e);
                     self.bar.set_message(format!(
                         "[{}/{} {} {} {}]: State Err: {}",
-                        self.endpoint_name, self.container_id_chrs, self.job.uuid(), self.package_name, self.package_version, e
+                        self.endpoint_name,
+                        self.container_id_chrs,
+                        self.job.uuid(),
+                        self.package_name,
+                        self.package_version,
+                        e
                     ));
                     success = Some(false);
                 }
@@ -408,15 +465,27 @@ impl<'a> LogReceiver<'a> {
         let finish_msg = match success {
             Some(true) => format!(
                 "[{}/{} {} {} {}]: finished successfully",
-                self.endpoint_name, self.container_id_chrs, self.job.uuid(), self.package_name, self.package_version
+                self.endpoint_name,
+                self.container_id_chrs,
+                self.job.uuid(),
+                self.package_name,
+                self.package_version
             ),
             Some(false) => format!(
                 "[{}/{} {} {} {}]: finished with error",
-                self.endpoint_name, self.container_id_chrs, self.job.uuid(), self.package_name, self.package_version
+                self.endpoint_name,
+                self.container_id_chrs,
+                self.job.uuid(),
+                self.package_name,
+                self.package_version
             ),
             None => format!(
                 "[{}/{} {} {} {}]: finished",
-                self.endpoint_name, self.container_id_chrs, self.job.uuid(), self.package_name, self.package_version
+                self.endpoint_name,
+                self.container_id_chrs,
+                self.job.uuid(),
+                self.package_name,
+                self.package_version
             ),
         };
         self.bar.finish_with_message(finish_msg);
@@ -438,7 +507,10 @@ impl<'a> LogReceiver<'a> {
             Some({
                 let path = log_dir.join(format!(
                     "{}-{}-{}-{}.log",
-                    self.package_name, self.package_version, self.job.image(), self.job.uuid()
+                    self.package_name,
+                    self.package_version,
+                    self.job.image(),
+                    self.job.uuid()
                 ));
                 tokio::fs::OpenOptions::new()
                     .create(true)

--- a/src/endpoint/util.rs
+++ b/src/endpoint/util.rs
@@ -21,10 +21,8 @@ pub async fn setup_endpoints(endpoints: Vec<EndpointConfiguration>) -> Result<Ve
     let unordered = futures::stream::FuturesUnordered::new();
 
     for cfg in endpoints.into_iter() {
-        unordered
-            .push(Endpoint::setup(cfg).map(|r_ep| r_ep.map(Arc::new)));
+        unordered.push(Endpoint::setup(cfg).map(|r_ep| r_ep.map(Arc::new)));
     }
 
     unordered.collect().await
 }
-

--- a/src/filestore/path.rs
+++ b/src/filestore/path.rs
@@ -36,11 +36,12 @@ impl StoreRoot {
                     "Creating a missing release store directory: {}",
                     root.display()
                 );
-                std::fs::create_dir(&root)
-                    .with_context(|| anyhow!(
+                std::fs::create_dir(&root).with_context(|| {
+                    anyhow!(
                         "Couldn't automatically create the following release store directory: {}",
                         root.display()
-                    ))?;
+                    )
+                })?;
                 Ok(StoreRoot(root))
             } else {
                 Err(anyhow!(
@@ -106,7 +107,10 @@ impl StoreRoot {
     /// `self` and returns the written pathes.
     ///
     /// The function filteres out the "/output" directory (that's what is meant by "butido-style").
-    pub(in crate::filestore) fn unpack_archive_here<R>(&self, mut ar: tar::Archive<R>) -> Result<Vec<PathBuf>>
+    pub(in crate::filestore) fn unpack_archive_here<R>(
+        &self,
+        mut ar: tar::Archive<R>,
+    ) -> Result<Vec<PathBuf>>
     where
         R: std::io::Read,
     {
@@ -132,9 +136,7 @@ impl StoreRoot {
                 let unpack_dest = self.0.join(&path);
                 trace!("Unpack to = '{:?}'", unpack_dest);
 
-                entry.unpack(unpack_dest)
-                    .map(|_| path)
-                    .map_err(Error::from)
+                entry.unpack(unpack_dest).map(|_| path).map_err(Error::from)
             })
             .collect::<Result<Vec<_>>>()
     }
@@ -185,7 +187,6 @@ impl AsRef<Path> for ArtifactPath {
 pub struct FullArtifactPath<'a>(&'a StoreRoot, &'a ArtifactPath);
 
 impl<'a> FullArtifactPath<'a> {
-
     pub fn is_in_staging_store(&self, store: &StagingStore) -> bool {
         store.0.root_path() == self.0
     }

--- a/src/filestore/staging.rs
+++ b/src/filestore/staging.rs
@@ -10,14 +10,14 @@
 
 use std::fmt::Debug;
 
+use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
-use anyhow::anyhow;
 use futures::stream::Stream;
 use indicatif::ProgressBar;
-use tracing::trace;
 use result_inspect::ResultInspect;
+use tracing::trace;
 
 use crate::filestore::path::ArtifactPath;
 use crate::filestore::path::StoreRoot;

--- a/src/job/dag.rs
+++ b/src/job/dag.rs
@@ -50,27 +50,22 @@ impl Dag {
     }
 
     pub fn iter(&'_ self) -> impl Iterator<Item = JobDefinition> + '_ {
-        self.dag
-            .graph()
-            .node_indices()
-            .map(move |idx| {
-                let job = self.dag.graph().node_weight(idx).unwrap(); // TODO
-                let children = self.dag.children(idx);
-                let children_uuids = children.iter(&self.dag)
-                    .filter_map(|(_, node_idx)| {
-                        self.dag.graph().node_weight(node_idx)
-                    })
-                    .map(Job::uuid)
-                    .cloned()
-                    .collect();
+        self.dag.graph().node_indices().map(move |idx| {
+            let job = self.dag.graph().node_weight(idx).unwrap(); // TODO
+            let children = self.dag.children(idx);
+            let children_uuids = children
+                .iter(&self.dag)
+                .filter_map(|(_, node_idx)| self.dag.graph().node_weight(node_idx))
+                .map(Job::uuid)
+                .cloned()
+                .collect();
 
-                JobDefinition {
-                    job,
-                    dependencies: children_uuids
-                }
-            })
+            JobDefinition {
+                job,
+                dependencies: children_uuids,
+            }
+        })
     }
-
 }
 
 #[derive(Debug)]
@@ -78,4 +73,3 @@ pub struct JobDefinition<'a> {
     pub job: &'a Job,
     pub dependencies: Vec<Uuid>,
 }
-

--- a/src/job/runnable.rs
+++ b/src/job/runnable.rs
@@ -24,8 +24,8 @@ use crate::package::Script;
 use crate::package::ScriptBuilder;
 use crate::source::SourceCache;
 use crate::source::SourceEntry;
-use crate::util::EnvironmentVariableName;
 use crate::util::docker::ImageName;
+use crate::util::EnvironmentVariableName;
 
 /// A job configuration that can be run. All inputs are clear here.
 #[derive(Debug, Getters)]
@@ -75,7 +75,11 @@ impl RunnableJob {
                 .chain(git_commit_env.as_ref().into_iter().map(|(k, v)| (k, v)))
                 .inspect(|(name, _)| debug!("Checking: {}", name))
                 .try_for_each(|(name, _)| {
-                    trace!("{:?} contains? {:?}", config.containers().allowed_env(), name);
+                    trace!(
+                        "{:?} contains? {:?}",
+                        config.containers().allowed_env(),
+                        name
+                    );
                     if !config.containers().allowed_env().contains(name) {
                         Err(anyhow!("Environment variable name not allowed: {}", name))
                     } else {
@@ -130,17 +134,13 @@ impl RunnableJob {
     }
 
     pub fn environment(&self) -> impl Iterator<Item = (&EnvironmentVariableName, &String)> {
-        self.resources
-            .iter()
-            .filter_map(|r| r.env())
-            .chain({
-                self.package()
-                    .environment()
-                    .as_ref()
-                    .map(|hm| hm.iter())
-                    .into_iter()
-                    .flatten()
-            })
+        self.resources.iter().filter_map(|r| r.env()).chain({
+            self.package()
+                .environment()
+                .as_ref()
+                .map(|hm| hm.iter())
+                .into_iter()
+                .flatten()
+        })
     }
-
 }

--- a/src/log/parser.rs
+++ b/src/log/parser.rs
@@ -43,14 +43,14 @@ impl std::fmt::Debug for ParsedLog {
         writeln!(f, "ParsedLog [")?;
         for (i, line) in self.0.iter().enumerate() {
             match line {
-                LogItem::Line(l)         => {
+                LogItem::Line(l) => {
                     let s = std::str::from_utf8(l).unwrap_or("ERROR UTF8 ENCODING");
                     writeln!(f, "[{i}] Line('{s}')")?
-                },
-                LogItem::Progress(u)     => writeln!(f, "[{i}] Progress({u})")?,
+                }
+                LogItem::Progress(u) => writeln!(f, "[{i}] Progress({u})")?,
                 LogItem::CurrentPhase(s) => writeln!(f, "[{i}] Phase({s})")?,
-                LogItem::State(Ok(_))    => writeln!(f, "[{i}] State::OK")?,
-                LogItem::State(Err(_))   => writeln!(f, "[{i}] State::Err")?,
+                LogItem::State(Ok(_)) => writeln!(f, "[{i}] State::OK")?,
+                LogItem::State(Err(_)) => writeln!(f, "[{i}] State::Err")?,
             }
         }
 
@@ -74,7 +74,7 @@ impl FromStr for ParsedLog {
 pub enum JobResult {
     Success,
     Errored,
-    Unknown
+    Unknown,
 }
 
 impl JobResult {
@@ -93,7 +93,7 @@ impl ParsedLog {
             .iter()
             .rev()
             .filter_map(|line| match line {
-                LogItem::State(Ok(_))  => Some(JobResult::Success),
+                LogItem::State(Ok(_)) => Some(JobResult::Success),
                 LogItem::State(Err(_)) => Some(JobResult::Errored),
                 _ => None,
             })

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -13,4 +13,3 @@ mod orchestrator;
 pub use orchestrator::*;
 
 mod util;
-

--- a/src/orchestrator/util.rs
+++ b/src/orchestrator/util.rs
@@ -27,12 +27,12 @@ impl AsReceivedErrorDisplay for HashMap<Uuid, Error> {
     }
 }
 
-
 pub struct ReceivedErrorDisplay<'a>(&'a HashMap<Uuid, Error>);
 
 impl<'a> std::fmt::Display for ReceivedErrorDisplay<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.iter().try_for_each(|(uuid, err)| writeln!(f, "{uuid}: {err}"))
+        self.0
+            .iter()
+            .try_for_each(|(uuid, err)| writeln!(f, "{uuid}: {err}"))
     }
 }
-

--- a/src/package/dependency/build.rs
+++ b/src/package/dependency/build.rs
@@ -12,21 +12,18 @@ use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::package::PackageName;
-use crate::package::PackageVersionConstraint;
+use crate::package::dependency::condition::Condition;
 use crate::package::dependency::ParseDependency;
 use crate::package::dependency::StringEqual;
-use crate::package::dependency::condition::Condition;
+use crate::package::PackageName;
+use crate::package::PackageVersionConstraint;
 
 /// A dependency that is packaged and is only required during build time
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(untagged)]
 pub enum BuildDependency {
     Simple(String),
-    Conditional {
-        name: String,
-        condition: Condition,
-    },
+    Conditional { name: String, condition: Condition },
 }
 
 impl AsRef<str> for BuildDependency {
@@ -49,7 +46,9 @@ impl StringEqual for BuildDependency {
 
 impl ParseDependency for BuildDependency {
     fn parse_as_name_and_version(&self) -> Result<(PackageName, PackageVersionConstraint)> {
-        crate::package::dependency::parse_package_dependency_string_into_name_and_version(self.as_ref())
+        crate::package::dependency::parse_package_dependency_string_into_name_and_version(
+            self.as_ref(),
+        )
     }
 }
 
@@ -66,7 +65,8 @@ mod tests {
 
     #[test]
     fn test_parse_dependency() {
-        let s: TestSetting = toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
+        let s: TestSetting =
+            toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
         match s.setting {
             BuildDependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {name}"),
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
@@ -75,14 +75,19 @@ mod tests {
 
     #[test]
     fn test_parse_conditional_dependency() {
-        let s: TestSetting = toml::from_str(r#"setting = { name = "foo", condition = { in_image = "bar"} }"#).expect("Parsing TestSetting failed");
+        let s: TestSetting =
+            toml::from_str(r#"setting = { name = "foo", condition = { in_image = "bar"} }"#)
+                .expect("Parsing TestSetting failed");
         match s.setting {
             BuildDependency::Conditional { name, condition } => {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -103,12 +108,14 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
-
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[allow(unused)]
@@ -118,14 +125,19 @@ mod tests {
 
     #[test]
     fn test_parse_conditional_dependencies() {
-        let s: TestSettings = toml::from_str(r#"settings = [{ name = "foo", condition = { in_image = "bar"} }]"#).expect("Parsing TestSetting failed");
+        let s: TestSettings =
+            toml::from_str(r#"settings = [{ name = "foo", condition = { in_image = "bar"} }]"#)
+                .expect("Parsing TestSetting failed");
         match s.settings.get(0).expect("Has not one dependency") {
             BuildDependency::Conditional { name, condition } => {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -145,8 +157,11 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -166,10 +181,12 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 }
-

--- a/src/package/dependency/runtime.rs
+++ b/src/package/dependency/runtime.rs
@@ -12,21 +12,18 @@ use anyhow::Result;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::package::PackageName;
-use crate::package::PackageVersionConstraint;
+use crate::package::dependency::condition::Condition;
 use crate::package::dependency::ParseDependency;
 use crate::package::dependency::StringEqual;
-use crate::package::dependency::condition::Condition;
+use crate::package::PackageName;
+use crate::package::PackageVersionConstraint;
 
 /// A dependency that is packaged and is required during runtime
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[serde(untagged)]
 pub enum Dependency {
     Simple(String),
-    Conditional {
-        name: String,
-        condition: Condition,
-    },
+    Conditional { name: String, condition: Condition },
 }
 
 #[cfg(test)]
@@ -62,7 +59,9 @@ impl From<String> for Dependency {
 
 impl ParseDependency for Dependency {
     fn parse_as_name_and_version(&self) -> Result<(PackageName, PackageVersionConstraint)> {
-        crate::package::dependency::parse_package_dependency_string_into_name_and_version(self.as_ref())
+        crate::package::dependency::parse_package_dependency_string_into_name_and_version(
+            self.as_ref(),
+        )
     }
 }
 
@@ -79,7 +78,8 @@ mod tests {
 
     #[test]
     fn test_parse_dependency() {
-        let s: TestSetting = toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
+        let s: TestSetting =
+            toml::from_str(r#"setting = "foo""#).expect("Parsing TestSetting failed");
 
         match s.setting {
             Dependency::Simple(name) => assert_eq!(name, "foo", "Expected 'foo', got {name}"),
@@ -89,14 +89,19 @@ mod tests {
 
     #[test]
     fn test_parse_conditional_dependency() {
-        let s: TestSetting = toml::from_str(r#"setting = { name = "foo", condition = { in_image = "bar"} }"#).expect("Parsing TestSetting failed");
+        let s: TestSetting =
+            toml::from_str(r#"setting = { name = "foo", condition = { in_image = "bar"} }"#)
+                .expect("Parsing TestSetting failed");
         match s.setting {
             Dependency::Conditional { name, condition } => {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -117,12 +122,14 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
-
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[allow(unused)]
@@ -132,14 +139,19 @@ mod tests {
 
     #[test]
     fn test_parse_conditional_dependencies() {
-        let s: TestSettings = toml::from_str(r#"settings = [{ name = "foo", condition = { in_image = "bar"} }]"#).expect("Parsing TestSetting failed");
+        let s: TestSettings =
+            toml::from_str(r#"settings = [{ name = "foo", condition = { in_image = "bar"} }]"#)
+                .expect("Parsing TestSetting failed");
         match s.settings.get(0).expect("Has not one dependency") {
             Dependency::Conditional { name, condition } => {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -159,8 +171,11 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -180,8 +195,11 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
@@ -205,8 +223,11 @@ mod tests {
                 assert_eq!(name, "foo", "Expected 'foo', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("bar"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("bar")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
 
@@ -215,10 +236,12 @@ mod tests {
                 assert_eq!(name, "baz", "Expected 'baz', got {name}");
                 assert_eq!(*condition.has_env(), None);
                 assert_eq!(*condition.env_eq(), None);
-                assert_eq!(condition.in_image().as_ref(), Some(&OneOrMore::<String>::One(String::from("boogie"))));
-            },
+                assert_eq!(
+                    condition.in_image().as_ref(),
+                    Some(&OneOrMore::<String>::One(String::from("boogie")))
+                );
+            }
             other => panic!("Unexpected deserialization to other variant: {other:?}"),
         }
     }
 }
-

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -135,50 +135,83 @@ pub struct DebugPackage<'a>(&'a Package);
 #[cfg(debug_assertions)]
 impl<'a> std::fmt::Debug for DebugPackage<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        writeln!(f, "Package({name} {version} ({semver}))",
+        writeln!(
+            f,
+            "Package({name} {version} ({semver}))",
             name = self.0.name,
             version = self.0.version,
-            semver = if self.0.version_is_semver { "is semver" } else { "not semver" })?;
+            semver = if self.0.version_is_semver {
+                "is semver"
+            } else {
+                "not semver"
+            }
+        )?;
 
         writeln!(f, "\tSources = ")?;
-        self.0.sources.iter().try_for_each(|(k, v)| writeln!(f, "\t\t{name} = (Url = {url}, Hash = {hash} ({hasht}), {dl})",
-            name = k,
-            url = v.url(),
-            hash = v.hash().value(),
-            hasht = v.hash().hashtype(),
-            dl = if *v.download_manually() { "manual download" } else { "automatic download" },
-        ))?;
+        self.0.sources.iter().try_for_each(|(k, v)| {
+            writeln!(
+                f,
+                "\t\t{name} = (Url = {url}, Hash = {hash} ({hasht}), {dl})",
+                name = k,
+                url = v.url(),
+                hash = v.hash().value(),
+                hasht = v.hash().hashtype(),
+                dl = if *v.download_manually() {
+                    "manual download"
+                } else {
+                    "automatic download"
+                },
+            )
+        })?;
 
         writeln!(f, "\tBuild Dependencies = ")?;
-        self.0.dependencies.build.iter().try_for_each(|d| writeln!(f, "\t\t{d:?}"))?;
+        self.0
+            .dependencies
+            .build
+            .iter()
+            .try_for_each(|d| writeln!(f, "\t\t{d:?}"))?;
 
         writeln!(f, "\tRuntime Dependencies = ")?;
-        self.0.dependencies.runtime.iter().try_for_each(|r| writeln!(f, "\t\t{r:?}"))?;
+        self.0
+            .dependencies
+            .runtime
+            .iter()
+            .try_for_each(|r| writeln!(f, "\t\t{r:?}"))?;
 
         writeln!(f, "\tPatches = ")?;
-        self.0.patches.iter().try_for_each(|p| writeln!(f, "\t\t{}", p.display()))?;
+        self.0
+            .patches
+            .iter()
+            .try_for_each(|p| writeln!(f, "\t\t{}", p.display()))?;
 
         writeln!(f, "\tEnvironment = ")?;
-        self.0.environment
+        self.0
+            .environment
             .as_ref()
-            .map(|hm| hm.iter().try_for_each(|(k, v)| writeln!(f, "\t\t{k:?} = {v}")))
+            .map(|hm| {
+                hm.iter()
+                    .try_for_each(|(k, v)| writeln!(f, "\t\t{k:?} = {v}"))
+            })
             .transpose()?;
 
         writeln!(f, "\tAllowed Images = ")?;
 
-        self.0.allowed_images
+        self.0
+            .allowed_images
             .as_ref()
             .map(|v| v.iter().try_for_each(|i| writeln!(f, "\t\t{i:?}")))
             .transpose()?;
 
         writeln!(f, "\tDenied Images = ")?;
-        self.0.denied_images
+        self.0
+            .denied_images
             .as_ref()
             .map(|v| v.iter().try_for_each(|i| writeln!(f, "\t\t{i:?}")))
             .transpose()?;
 
         writeln!(f, "\tPhases = ")?;
-        self.0.phases
+        self.0
+            .phases
             .iter()
             .try_for_each(|(k, _)| writeln!(f, "\t\t{k:?} = ..."))?;
 

--- a/src/package/source.rs
+++ b/src/package/source.rs
@@ -12,9 +12,9 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Result;
 use getset::Getters;
-use tracing::trace;
 use serde::Deserialize;
 use serde::Serialize;
+use tracing::trace;
 use url::Url;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
@@ -52,7 +52,8 @@ pub struct SourceHash {
 impl SourceHash {
     pub async fn matches_hash_of<R: tokio::io::AsyncRead + Unpin>(&self, reader: R) -> Result<()> {
         trace!("Hashing buffer with: {:?}", self.hashtype);
-        let h = self.hashtype
+        let h = self
+            .hashtype
             .hash_from_reader(reader)
             .await
             .context("Hashing failed")?;
@@ -93,7 +94,10 @@ pub enum HashType {
 }
 
 impl HashType {
-    async fn hash_from_reader<R: tokio::io::AsyncRead + Unpin>(&self, mut reader: R) -> Result<HashValue> {
+    async fn hash_from_reader<R: tokio::io::AsyncRead + Unpin>(
+        &self,
+        mut reader: R,
+    ) -> Result<HashValue> {
         use tokio::io::AsyncReadExt;
 
         let mut buffer = [0; 1024];
@@ -105,7 +109,8 @@ impl HashType {
                 trace!("SHA1 hashing buffer");
                 let mut m = sha1::Sha1::new();
                 loop {
-                    let count = reader.read(&mut buffer)
+                    let count = reader
+                        .read(&mut buffer)
                         .await
                         .context("Reading buffer failed")?;
 
@@ -124,7 +129,8 @@ impl HashType {
                 trace!("SHA256 hashing buffer");
                 let mut m = sha2::Sha256::new();
                 loop {
-                    let count = reader.read(&mut buffer)
+                    let count = reader
+                        .read(&mut buffer)
                         .await
                         .context("Reading buffer failed")?;
 
@@ -145,7 +151,8 @@ impl HashType {
                 trace!("SHA512 hashing buffer");
                 let mut m = sha2::Sha512::new();
                 loop {
-                    let count = reader.read(&mut buffer)
+                    let count = reader
+                        .read(&mut buffer)
                         .await
                         .context("Reading buffer failed")?;
 

--- a/src/package/version.rs
+++ b/src/package/version.rs
@@ -67,7 +67,6 @@ impl std::convert::TryFrom<&str> for PackageVersionConstraint {
             .context("Failed to parse package version constraint")
             .context("A package version constraint must have a comparator and a version string, like so: =0.1.0")
             .map_err(Error::from)
-
     }
 }
 
@@ -137,39 +136,17 @@ mod tests {
         assert!(PackageVersion::parser().parse(b"=a1").is_err());
         assert!(PackageVersion::parser().parse(b"a").is_err());
 
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"=")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"*1")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b">1")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"<1")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"=a")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"=.a")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"=.1")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"=a1")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"1")
-            .is_err());
-        assert!(PackageVersionConstraint::parser()
-            .parse(b"a")
-            .is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"=").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"*1").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b">1").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"<1").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"=a").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"=.a").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"=.1").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"=a1").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"1").is_err());
+        assert!(PackageVersionConstraint::parser().parse(b"a").is_err());
     }
 
     #[test]

--- a/src/repository/fs/element.rs
+++ b/src/repository/fs/element.rs
@@ -18,7 +18,7 @@ use crate::repository::fs::path::PathComponent;
 #[derive(Debug)]
 pub enum Element {
     File(String),
-    Dir(HashMap<PathComponent, Element>)
+    Dir(HashMap<PathComponent, Element>),
 }
 
 impl Element {
@@ -30,4 +30,3 @@ impl Element {
         }
     }
 }
-

--- a/src/repository/fs/mod.rs
+++ b/src/repository/fs/mod.rs
@@ -13,4 +13,3 @@ pub use representation::FileSystemRepresentation;
 
 mod element;
 mod path;
-

--- a/src/repository/fs/path.rs
+++ b/src/repository/fs/path.rs
@@ -48,7 +48,7 @@ impl TryFrom<&std::path::Component<'_>> for PathComponent {
                 } else {
                     Ok(PathComponent::DirName(filename.to_string()))
                 }
-            },
+            }
         }
     }
 }
@@ -64,8 +64,7 @@ impl PathComponent {
     pub fn dir_name(&self) -> Option<&str> {
         match self {
             PathComponent::PkgToml => None,
-            PathComponent::DirName(dn) => Some(dn)
+            PathComponent::DirName(dn) => Some(dn),
         }
     }
 }
-

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -13,4 +13,3 @@ mod repository;
 pub use repository::*;
 
 mod fs;
-

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -16,10 +16,10 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
-use tracing::trace;
 use resiter::AndThen;
 use resiter::FilterMap;
 use resiter::Map;
+use tracing::trace;
 
 use crate::package::Package;
 use crate::package::PackageName;
@@ -54,7 +54,8 @@ impl Repository {
 
         fn get_patches(config: &Config) -> Result<Vec<PathBuf>> {
             match config.get_array("patches") {
-                Ok(v)  => v.into_iter()
+                Ok(v) => v
+                    .into_iter()
                     .map(config::Value::into_str)
                     .map_err(Error::from)
                     .map_err(|e| e.context("patches must be strings"))

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -101,10 +101,7 @@ impl SourceEntry {
             .context("Opening file failed")?;
 
         trace!("Reader constructed for path: {}", p.display());
-        self.package_source
-            .hash()
-            .matches_hash_of(reader)
-            .await
+        self.package_source.hash().matches_hash_of(reader).await
     }
 
     pub async fn create(&self) -> Result<tokio::fs::File> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,8 +13,8 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use anyhow::Result;
 use anyhow::anyhow;
+use anyhow::Result;
 use itertools::Itertools;
 
 use crate::config::Configuration;

--- a/src/ui/package.rs
+++ b/src/ui/package.rs
@@ -59,17 +59,30 @@ impl PackagePrintFlags {
     }
 }
 
-
 pub trait PreparePrintable<'a>
-    where Self: Borrow<Package> + Sized
+where
+    Self: Borrow<Package> + Sized,
 {
-    fn prepare_print(self, config: &'a Configuration, flags: &'a PackagePrintFlags, handlebars: &'a Handlebars<'a>, i: usize) -> PreparePrintPackage<'a, Self>;
+    fn prepare_print(
+        self,
+        config: &'a Configuration,
+        flags: &'a PackagePrintFlags,
+        handlebars: &'a Handlebars<'a>,
+        i: usize,
+    ) -> PreparePrintPackage<'a, Self>;
 }
 
 impl<'a, P> PreparePrintable<'a> for P
-    where P: Borrow<Package>
+where
+    P: Borrow<Package>,
 {
-    fn prepare_print(self, config: &'a Configuration, flags: &'a PackagePrintFlags, handlebars: &'a Handlebars<'a>, i: usize) -> PreparePrintPackage<'a, P> {
+    fn prepare_print(
+        self,
+        config: &'a Configuration,
+        flags: &'a PackagePrintFlags,
+        handlebars: &'a Handlebars<'a>,
+        i: usize,
+    ) -> PreparePrintPackage<'a, P> {
         PreparePrintPackage {
             package: self,
             config,
@@ -88,7 +101,6 @@ pub struct PreparePrintPackage<'a, P: Borrow<Package>> {
     i: usize,
 }
 
-
 pub fn handlebars_for_package_printing(format: &str) -> Result<Handlebars> {
     let mut hb = Handlebars::new();
     hb.register_escape_fn(handlebars::no_escape);
@@ -98,11 +110,13 @@ pub fn handlebars_for_package_printing(format: &str) -> Result<Handlebars> {
 
 impl<'a, P: Borrow<Package>> PreparePrintPackage<'a, P> {
     pub fn into_displayable(self) -> Result<PrintablePackage> {
-        let script = ScriptBuilder::new(&Shebang::from(self.config.shebang().clone())).build(
-            self.package.borrow(),
-            self.config.available_phases(),
-            *self.config.strict_script_interpolation(),
-        ).context("Rendering script for printing it failed")?;
+        let script = ScriptBuilder::new(&Shebang::from(self.config.shebang().clone()))
+            .build(
+                self.package.borrow(),
+                self.config.available_phases(),
+                *self.config.strict_script_interpolation(),
+            )
+            .context("Rendering script for printing it failed")?;
 
         let script = crate::ui::script_to_printable(
             &script,
@@ -110,12 +124,17 @@ impl<'a, P: Borrow<Package>> PreparePrintPackage<'a, P> {
             self.config
                 .script_highlight_theme()
                 .as_ref()
-                .ok_or_else(|| anyhow!("Highlighting for script enabled, but no theme configured"))?,
+                .ok_or_else(|| {
+                    anyhow!("Highlighting for script enabled, but no theme configured")
+                })?,
             self.flags.script_line_numbers,
         )?;
 
         let mut data = BTreeMap::new();
-        data.insert("i", serde_json::Value::Number(serde_json::Number::from(self.i)));
+        data.insert(
+            "i",
+            serde_json::Value::Number(serde_json::Number::from(self.i)),
+        );
         data.insert("p", serde_json::to_value(self.package.borrow())?);
         data.insert("script", serde_json::Value::String(script));
         data.insert("print_any", serde_json::Value::Bool(self.flags.print_any()));
@@ -170,11 +189,12 @@ impl<'a, P: Borrow<Package>> PreparePrintPackage<'a, P> {
     }
 }
 
-pub struct PrintablePackage { string: String }
+pub struct PrintablePackage {
+    string: String,
+}
 
 impl std::fmt::Display for PrintablePackage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.string)
     }
 }
-

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -11,8 +11,8 @@
 use anyhow::Error;
 use anyhow::Result;
 use filters::failable::filter::FailableFilter;
-use tracing::trace;
 use resiter::Map;
+use tracing::trace;
 
 use crate::package::Package;
 use crate::package::PackageName;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -39,7 +39,6 @@ impl AsRef<str> for EnvironmentVariableName {
     }
 }
 
-
 pub mod docker;
 pub mod env;
 pub mod filters;

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -8,8 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 //
 
-use indicatif::*;
 use getset::CopyGetters;
+use indicatif::*;
 
 #[derive(Clone, Debug, CopyGetters)]
 pub struct ProgressBars {
@@ -21,10 +21,7 @@ pub struct ProgressBars {
 
 impl ProgressBars {
     pub fn setup(bar_template: String, hide: bool) -> Self {
-        ProgressBars {
-            bar_template,
-            hide,
-        }
+        ProgressBars { bar_template, hide }
     }
 
     pub fn bar(&self) -> anyhow::Result<ProgressBar> {


### PR DESCRIPTION
The first commit is the result of `cargo fmt` and the second commit adds a CI check to ensure that we won't run into this "problem" again. This PR is quite overdue (I delayed it to avoid unnecessary conflicts with other active/open PRs (especially #132)).

The first commit also contains a small manual change as running `cargo fmt` resulted in the following regression:
```console
$ cargo check -r
    Checking butido v0.4.0
error: unnecessary braces around method argument
   --> src/commands/endpoint.rs:405:20
    |
405 |             .chain({ data.values().flat_map(|hm| hm.keys()).map(|s| s.deref()) })
    |                    ^^                                                         ^^
    |
note: the lint level is defined here
   --> src/main.rs:32:5
    |
32  |     unused,
    |     ^^^^^^
    = note: `#[deny(unused_braces)]` implied by `#[deny(unused)]`
help: remove these braces
    |
405 -             .chain({ data.values().flat_map(|hm| hm.keys()).map(|s| s.deref()) })
405 +             .chain(data.values().flat_map(|hm| hm.keys()).map(|s| s.deref()))
    |

error: could not compile `butido` (bin "butido") due to previous error
```

We could also consider overriding some `rustfmt` settings (https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=) to reduce the size of the diff / avoid somewhat "unnecessary" changes.