### PR TITLE
Fix Clippy warnings

### DIFF
--- a/src/commands/endpoint.rs
+++ b/src/commands/endpoint.rs
@@ -394,7 +394,7 @@ async fn containers_top(
             let hm = top
                 .titles
                 .into_iter()
-                .zip(processes.into_iter())
+                .zip(processes)
                 .collect::<HashMap<String, Vec<String>>>();
             (container_id, hm)
         })

--- a/src/commands/source/mod.rs
+++ b/src/commands/source/mod.rs
@@ -253,15 +253,13 @@ async fn of(matches: &ArgMatches, config: &Configuration, repo: Repository) -> R
 
             (p, pathes)
         })
-        .fold(Ok(std::io::stdout()), |out, (package, pathes)| {
-            out.and_then(|mut out| {
-                writeln!(out, "{} {}", package.name(), package.version())?;
-                for path in pathes {
-                    writeln!(out, "\t{}", path.display())?;
-                }
+        .try_fold(std::io::stdout(), |mut out, (package, pathes)| {
+            writeln!(out, "{} {}", package.name(), package.version())?;
+            for path in pathes {
+                writeln!(out, "\t{}", path.display())?;
+            }
 
-                Ok(out)
-            })
+            Ok(out)
         })
         .map(|_| ())
 }

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -262,7 +262,7 @@ impl Borrow<ArtifactPath> for ProducedArtifact {
 impl<'a> Orchestrator<'a> {
     pub async fn run(self, output: &mut Vec<ArtifactPath>) -> Result<HashMap<Uuid, Error>> {
         let (results, errors) = self.run_tree().await?;
-        output.extend(results.into_iter());
+        output.extend(results);
         Ok(errors)
     }
 
@@ -690,8 +690,8 @@ impl<'a> JobTask<'a> {
                 .iter()
                 .filter_map(crate::job::JobResource::env)
                 .map(|(k, v)| (k.clone(), v.clone()))
-                .chain(self.git_author_env.cloned().into_iter())
-                .chain(self.git_commit_env.cloned().into_iter())
+                .chain(self.git_author_env.cloned())
+                .chain(self.git_commit_env.cloned())
                 .collect::<Vec<_>>();
 
             let replacement_artifacts = crate::db::FindArtifacts::builder()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
New warnings appeared since the beta toolchain was bumped to 1.72 (after stable got bumped to 1.71.0: https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html - I planned on adding those commits to #263 as the Rust/Clippy version got bumped between the PR was opened and merged but I forgot about it during the weekend (and they're unrelated to that PR)).

Anyway, this just fixes an optional CI check to make everything green again :)