### PR TITLE
Resolve all warnings detected by clippy 0.1.73 (beta toolchain)

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -101,6 +101,7 @@ jobs:
         include:
           - rust: 1.67.0 # MSRV
             optional: false
+            extra_opts: "-A unknown-lints"
           - rust: beta
             optional: true
     steps:
@@ -113,7 +114,7 @@ jobs:
         with:
           shared-key: "ci"
       - name: cargo clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings ${{ matrix.extra_opts }}
 
   # This "accumulation" job is used as the required CI check for PRs.
   # We could require multiple jobs but the MSRV is subject to change and makes

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -98,12 +98,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust:
-          - beta
-        optional: [true]
         include:
           - rust: 1.67.0 # MSRV
             optional: false
+          - rust: beta
+            optional: true
     steps:
       - uses: actions/checkout@v3.5.3
       - uses: dtolnay/rust-toolchain@v1

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -144,6 +144,7 @@ async fn new_release(
     let any_err = arts
         .into_iter()
         .map(|art| async {
+            #[allow(clippy::redundant_locals)]
             let art = art; // ensure it is moved
             let art_path = staging_base.join(&art.path);
             let dest_path = config

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -227,7 +227,7 @@ impl PartialEq for Package {
 
 impl PartialOrd for Package {
     fn partial_cmp(&self, other: &Package) -> Option<std::cmp::Ordering> {
-        (self.name(), self.version()).partial_cmp(&(other.name(), other.version()))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
This allows the `redundant_locals` lint [0] for a function where it's usage is convenient for moving only a single variable into a closure while still borrowing the captured variables from the environment (there are alternatives but they're more verbose).

The other lint [1] detected a manual implementation of both `PartialOrd` and `Ord` for the `Package` struct. For correctness, the implementation of `Ord` should be reused for `PartialOrd` to ensure that they always behave the same.

[0]: https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_locals
[1]: https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->

The full clippy output:
```
$ cargo clippy -r
   Compiling butido v0.4.0
error: redundant redefinition of a binding
   --> src/commands/release.rs:146:15
    |
146 |         .map(|art| async {
    |               ^^^
147 |             let art = art; // ensure it is moved
    |             ^^^^^^^^^^^^^^
    |
    = help: remove the redefinition of `art`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_locals
    = note: `#[deny(clippy::redundant_locals)]` on by default

error: incorrect implementation of `partial_cmp` on an `Ord` type
   --> src/package/package.rs:228:1
    |
228 | /  impl PartialOrd for Package {
229 | |      fn partial_cmp(&self, other: &Package) -> Option<std::cmp::Ordering> {
    | | __________________________________________________________________________-
230 | ||         (self.name(), self.version()).partial_cmp(&(other.name(), other.version()))
231 | ||     }
    | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
232 | |  }
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
    = note: `#[deny(clippy::incorrect_partial_ord_impl_on_ord_type)]` on by default

error: could not compile `butido` (bin "butido") due to 2 previous errors
```