### PR TITLE
Fix the progress bar for the repository loading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ async fn main() -> Result<()> {
 
     let load_repo = || -> Result<Repository> {
         let bar = progressbars.bar()?;
+        bar.set_message("Loading repository...");
         let repo = Repository::load(repo_path, &bar).context("Loading the repository")?;
         bar.finish_with_message("Repository loading finished");
         Ok(repo)


### PR DESCRIPTION
The progress bar was broken (jumped from 0% straight to 100%). This fixes that by properly initializing the length and incrementing the progress bar with each file that is being read (calling `inc()` does advance the position/progress and also calls `tick()`). Let's also set a message that is shown during the repository loading.

It's still not perfect as `FileSystemRepresentation::load` could also take a significant amount of time (I ran into a weird kernel/FS issue that made the `getdents64` syscall extremely slow so that part took by far the most amount of time (~30 sec!)) but it should usually be a good approximation (as `FileSystemRepresentation::load` should only take a bit less then 1/10 of the time) and we cannot really determine in advance how long it'll take to enumerate the files in the repository.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
