### PR TITLE
Set the Rust edition in rustfmt.toml to fix rustfmt errors

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
-newline_style="Unix"
+edition = "2021"
+newline_style = "Unix"


### PR DESCRIPTION
This shouldn't be required / is redundant as the Rust edition is already set in Cargo.toml but that only works for `cargo fmt` and not `rustfmt`:
```
$ rustfmt src/main.rs
error[E0670]: `async fn` is not permitted in Rust 2015
  --> /home/michael/butido/src/main.rs:93:1
   |
93 | async fn main() -> Result<()> {
   | ^^^^^ to use `async fn`, switch to Rust 2018 or later
   |
   = help: pass `--edition 2021` to `rustc`
   = note: for more on editions, read https://doc.rust-lang.org/edition-guide
```

This change is required for automatic Rust source code formatting with the official Vim plugin [0] (`rustfmt_autosave`) and might be required for other plugins/tooling as well (the `edition` setting defaults to "2015" [1] and `rust.vim` uses "2018" if no `rustfmt.toml` configuration file is present [2]).

[0]: https://github.com/rust-lang/rust.vim
[1]: https://rust-lang.github.io/rustfmt/?version=v1.4.36&search=#edition
[2]: https://github.com/rust-lang/rust.vim/blob/889b9a7515db477f4cb6808bef1769e53493c578/autoload/rustfmt.vim#L75

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
