### PR TITLE
Deny unknown fields in package configurations

### DIFF
--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -24,6 +24,7 @@ use crate::util::docker::ImageName;
 use crate::util::EnvironmentVariableName;
 
 #[derive(Clone, Serialize, Deserialize, Getters)]
+#[serde(deny_unknown_fields)]
 pub struct Package {
     #[getset(get = "pub")]
     name: PackageName,


### PR DESCRIPTION
This helps catching errors in package configuration files (`pkg.toml`) by rejecting unknown fields when loading the packages repository. The `config` crate is a bit limited in this regard but luckily this can be caught during deserialization via Serde [0][1].

The error output contains the path of the problematic package configuration file, the name of the unknown field, and a list of the valid/expected fields.

Fixes #188.

[0]: https://github.com/mehcode/config-rs/issues/450
[1]: https://serde.rs/container-attrs.html#deny_unknown_fields

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---
An example:
```console
$ git diff
diff --git a/tree/pkg.toml b/tree/pkg.toml
index 16b6cc69..7588436e 100644
--- a/tree/pkg.toml
+++ b/tree/pkg.toml
@@ -1,3 +1,6 @@
+fixup.script = '''
+     echo test
+'''
 name = "tree"

 [environment]
$ butido tree-of tree
Error: Loading the repository

Caused by:
    0: Could not load package configuration: tree/1.8.0/pkg.toml
    1: unknown field `fixup`, expected one of `name`, `version`, `version_is_semver`, `sources`, `dependencies`, `patches`, `environment`, `allowed_images`, `denied_images`, `phases`, `meta`

```