### PR TITLE
Mark build dependencies in the tree-of output with a star

### DIFF
--- a/src/job/dag.rs
+++ b/src/job/dag.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use crate::job::Job;
 use crate::job::JobResource;
+use crate::package::DependencyType;
 use crate::package::Package;
 use crate::package::PhaseName;
 use crate::package::Shebang;
@@ -23,7 +24,7 @@ use crate::util::docker::ImageName;
 #[derive(Debug, Getters)]
 pub struct Dag {
     #[getset(get = "pub")]
-    dag: DaggyDag<Job, i8>,
+    dag: DaggyDag<Job, DependencyType>,
 }
 
 impl Dag {
@@ -45,7 +46,7 @@ impl Dag {
         };
 
         Dag {
-            dag: dag.dag().map(build_job, |_, e| *e),
+            dag: dag.dag().map(build_job, |_, e| (*e).clone()),
         }
     }
 

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -64,7 +64,12 @@ pub(in crate::package::dependency) fn parse_package_dependency_string_into_name_
         .map(|m| String::from(m.as_str()))
         .ok_or_else(|| anyhow!("Could not parse version: '{}'", s))?;
 
-    let v = PackageVersionConstraint::try_from(vers)?;
+    let v = PackageVersionConstraint::try_from(vers).map_err(|e| {
+        e.context(anyhow!(
+            "Could not parse the following package dependency string: {}",
+            s
+        ))
+    })?;
     Ok((PackageName::from(name), v))
 }
 

--- a/src/package/version.rs
+++ b/src/package/version.rs
@@ -10,6 +10,7 @@
 
 use std::ops::Deref;
 
+use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
@@ -64,8 +65,8 @@ impl std::convert::TryFrom<&str> for PackageVersionConstraint {
     fn try_from(s: &str) -> Result<Self> {
         PackageVersionConstraint::parser()
             .parse(s.as_bytes())
-            .context("Failed to parse package version constraint")
-            .context("A package version constraint must have a comparator and a version string, like so: =0.1.0")
+            .context(anyhow!("Failed to parse the following package version constraint: {}", s))
+            .context("A package version constraint must have a comparator (only `=` is currently supported) and a version string, like so: =0.1.0")
             .map_err(Error::from)
     }
 }


### PR DESCRIPTION
This implements a feature requested in #177 by making it possible to distinguish between build and runtime dependencies in the tree-of output. It should also improve the comments, trace output, and error messages of the related code a bit. See the individual commits for more details.
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
