### PR TITLE
Fix all clippy and rustc warnings (beta toolchain version 0.1.74)

### DIFF
--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -371,10 +371,9 @@ struct LogReceiver<'a> {
 impl<'a> LogReceiver<'a> {
     async fn join(mut self) -> Result<String> {
         let mut success = None;
-        let mut accu = vec![];
 
         // Reserve a reasonable amount of elements.
-        accu.reserve(4096);
+        let mut accu = Vec::with_capacity(4096);
 
         let mut logfile = self
             .get_logfile()

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     trivial_numeric_casts,
     unconditional_recursion,
     unsafe_code,

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -63,7 +63,7 @@ impl Repository {
                     .map_ok(PathBuf::from)
                     .collect(),
                 Err(config::ConfigError::NotFound(_)) => Ok(Vec::with_capacity(0)),
-                Err(e) => Err(e).map_err(Error::from),
+                Err(e) => Err(Error::from(e)),
             }
         }
 


### PR DESCRIPTION
Just some minor cleanups - s. commit messages for more details.
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---
```console
$ cargo clippy -r --all-targets -- -D warnings
error: lint `private_in_public` has been removed: replaced with another group of lints, see RFC <https://rust-lang.github.io/rfcs/2145-type-privacy.html> for more information
  --> src/main.rs:27:5
   |
27 |     private_in_public,
   |     ^^^^^^^^^^^^^^^^^
   |
   = note: `-D renamed-and-removed-lints` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`

error: call to `reserve` immediately after creation
   --> src/endpoint/scheduler.rs:374:9
    |
374 | /         let mut accu = vec![];
375 | |
376 | |         // Reserve a reasonable amount of elements.
377 | |         accu.reserve(4096);
    | |___________________________^ help: consider using `Vec::with_capacity(/* Space hint */)`: `let mut accu = Vec::with_capacity(4096);`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#reserve_after_initialization
    = note: `-D clippy::reserve-after-initialization` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::reserve_after_initialization)]`

error: unnecessary map_err on constructor Err(_)
  --> src/repository/repository.rs:66:27
   |
66 |                 Err(e) => Err(e).map_err(Error::from),
   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Err(Error::from(e))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_on_constructor
   = note: `-D clippy::unnecessary-map-on-constructor` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_on_constructor)]`

error: could not compile `butido` (bin "butido") due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `butido` (bin "butido" test) due to 3 previous errors
```
