### PR TITLE
cargo-deny: Cleanup the ignore list for advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -64,10 +64,4 @@ skip-tree = [
 
 [advisories]
 ignore = [
-    # "Potential segfault in the time crate"
-    #
-    # Patches available, but as "time-rs" is not a direct dependency, we cannot
-    # do anything here
-    "RUSTSEC-2020-0071",
 ]
-


### PR DESCRIPTION
This exception isn't required anymore since we finally got rid of the old `time 0.1.x` dependency in b8e0579.
(-> the list is finally empty, as it should be \o/)

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---
I just noticed this unnecessary warning in the CI logs:
```
warning[advisory-not-detected]: advisory was not encountered
   ┌─ /github/workspace/deny.toml:71:5
   │
71 │     "RUSTSEC-2020-0071",
   │     ^^^^^^^^^^^^^^^^^^^ no crate matched advisory criteria

advisories ok
```
