### PR TITLE
Fix setting the default log level to WARN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,6 @@ dependencies = [
  "indoc",
  "itertools 0.11.0",
  "lazy_static",
- "log",
  "parse-display",
  "pom",
  "ptree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ indicatif      = "0.17"
 indoc          = "2"
 itertools      = "0.11"
 lazy_static    = "1"
-log            = "0.4"
 parse-display  = "0.8"
 pom            = "3"
 ptree          = { version = "0.4", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,8 +98,11 @@ async fn main() -> Result<()> {
     });
 
     tracing_subscriber::fmt::fmt()
-        .with_max_level(tracing::Level::WARN)
-        .with_env_filter(tracing_subscriber::filter::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::filter::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::WARN.into())
+                .from_env_lossy(),
+        )
         .init();
     debug!("Debugging enabled");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,6 @@
 #![allow(macro_use_extern_crate)]
 #![allow(unstable_name_collisions)] // TODO: Remove me with the next rustc update (probably)
 
-extern crate log as logcrate;
 #[macro_use]
 extern crate diesel;
 
@@ -55,8 +54,7 @@ use anyhow::Error;
 use anyhow::Result;
 use aquamarine as _;
 use clap::ArgMatches;
-use logcrate::debug;
-use logcrate::error; // doc-helper crate
+use tracing::{debug, error};
 
 mod cli;
 mod commands;


### PR DESCRIPTION
In 76150f0, we used `with_max_level()` to set the default log level but apparently the behaviour changed in the meantime (or we didn't test it correctly back then). The documentation of `with_env_filter` [0] states:
> If a filter was previously set, or a maximum level was set by the
with_max_level method, that value is replaced by the new filter.

The idea in 76150f0 was that `with_env_filter` would only override the default from `with_max_level` if the `$RUST_LOG` environment variable is set but the `EnvFilter::from_default_env()` also had a default log level (unfortunately it defaults to ERROR instead of WARN). We now replace `from_default_env()` with the underlying code [1] but changed the default log level from ERROR to WARN.

[0]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/struct.SubscriberBuilder.html#method.with_env_filter
[1]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/filter/struct.EnvFilter.html#method.from_default_env

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
