### PR TITLE
Improve the error handling of the source download command

### DIFF
--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -139,6 +139,15 @@ async fn perform_download(
         Err(e) => return Err(e).with_context(|| anyhow!("Downloading '{}'", &source.url())),
     };
 
+    if response.status() != reqwest::StatusCode::OK {
+        return Err(anyhow!(
+            "Received HTTP status code \"{}\" but \"{}\" is expected for a successful download",
+            response.status(),
+            reqwest::StatusCode::OK
+        ))
+        .with_context(|| anyhow!("Downloading \"{}\" failed", &source.url()));
+    }
+
     progress
         .lock()
         .await

--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -114,15 +114,8 @@ async fn perform_download(
     progress: Arc<Mutex<ProgressWrapper>>,
     timeout: Option<u64>,
 ) -> Result<()> {
-    trace!("Creating: {:?}", source);
-    let file = source.create().await.with_context(|| {
-        anyhow!(
-            "Creating source file destination: {}",
-            source.path().display()
-        )
-    })?;
+    trace!("Downloading: {:?}", source);
 
-    let mut file = tokio::io::BufWriter::new(file);
     let client_builder =
         reqwest::Client::builder().redirect(reqwest::redirect::Policy::limited(10));
 
@@ -172,6 +165,14 @@ async fn perform_download(
         "The server returned content type \"{content_type}\" for \"{}\"",
         source.url()
     );
+
+    let file = source.create().await.with_context(|| {
+        anyhow!(
+            "Creating source file destination: {}",
+            source.path().display()
+        )
+    })?;
+    let mut file = tokio::io::BufWriter::new(file);
 
     let mut stream = response.bytes_stream();
     while let Some(bytes) = stream.next().await {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
This builds upon #305 and avoids two more issues that we noticed:

1) An unsuccessful download still creates the source file (empty) -> subsequent attempts will fail (without --force). An example:
```console
$ export http_proxy=localhost:42
$ butido source download tree
[00:00:02] (100%): ████████████████████████████████████████ | Repository loading finished
[00:00:00] (100%): ████████████████████████████████████████ | At least one download of 1 failed
Error: source command failed

Caused by:
    0: Downloading 'http://mama.indstate.edu/users/ice/tree/src/tree-1.8.0.tgz'
    1: error sending request for url (http://mama.indstate.edu/users/ice/tree/src/tree-1.8.0.tgz): error trying to connect: tcp connect error: Connection refused (os error 111)
    2: error trying to connect: tcp connect error: Connection refused (os error 111)
    3: tcp connect error: Connection refused (os error 111)
    4: Connection refused (os error 111)
$ butido source download tree
[00:00:01] (100%): ████████████████████████████████████████ | Repository loading finished
[00:00:00] (100%): ████████████████████████████████████████ | At least one download of 0 failed
Error: source command failed

Caused by:
    Source exists: /srv/butido/sources/tree-1.8.0/src.source
$ file /srv/butido/sources/tree-1.8.0/src.source
/srv/butido/sources/tree-1.8.0/src.source: empty
```

2) The HTTP status code was never checked -> if the URL is invalid, butido will happily store the HTTP 404 Not Found HTML response as the source file, e.g.:
```console
$ butido source download tree                                                                                                                               [00:00:02] (100%): ████████████████████████████████████████ | Repository loading finished
[00:00:00] (100%): ████████████████████████████████████████ | Succeeded 1/1 downloads
$ file /srv/butido/sources/tree-1.8.0/src.source
/srv/butido/sources/tree-1.8.0/src.source: HTML document, ASCII text
$ cat /srv/butido/sources/tree-1.8.0/src.source
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
```
This now results in a fatal error instead:
```console
$ butido source download tree
[00:00:01] (100%): ████████████████████████████████████████ | Repository loading finished
[00:00:00] (100%): ████████████████████████████████████████ | At least one download of 1 failed
Error: source command failed

Caused by:
    0: Downloading "http://mama.indstate.edu/users/ice/tree/src/tree-1.8.42.tgz" failed
    1: Received HTTP status code "404 Not Found" but "200 OK" is expected for a successful download
```