### PR TITLE
dependabot: Ignore patch updates of Rust crates (Cargo)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
     interval: monthly
   open-pull-requests-limit: 30
   rebase-strategy: "disabled"
+  ignore:
+    # Ignore all patch updates for version updates only (we'll pull in SemVer
+    # compatible updates in batches using `cargo update` while dependabot's
+    # task is to perform "major" updates that require changes to `Cargo.toml`
+    # as well as security updates):
+  - dependency-name: "*"
+    update-types: ["version-update:semver-patch"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
We currently use the following strategy to avoid too many dependabot PRs (i.e., to reduce the noise and work required to merge them): We set the update interval to monthly and manually run `cargo update` just before the scheduled dependabot run to commit all compatible updates at once.

We only need dependabot to update `Cargo.toml` and to open PRs for security updates right away.

We don't lock any dependencies to specific patch version so we can instruct dependabot to ignore all patch updates as that should never require updates to `Cargo.toml`. This setting also shouldn't affect/prevent security updates (the documentation isn't that clear on this [0] but at least we'd notice as it certainly shouldn't affect the dependabot (security) alerts) and we still get the patch updates via our `cargo update` batches.
We cannot ignore minor updates as well due to `0.y.z` releases (we lock those to the minor version in `Cargo.toml` as patch releases usually don't change the API even though SemVer theoretically allows this).

PS: We're using the default dependabot configuration that only updates direct dependencies (except for security updates) so we need to perform major/minor/patch updates of indirect dependencies manually through `cargo update` anyway.

[0]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
