### PR TITLE
Replace our Atos email addresses with the new Eviden addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.4.0"
 authors = [
   # Only for the current/active maintainers (sorted alphabetically by the surname)
   # All other authors are listed in the "Authors" section of README.md
-  "Nico Steinle <nico.steinle@atos.net>", # @ammernico
-  "Michael Weiss <michael.weiss@atos.net>", # @primeos-work
+  "Nico Steinle <nico.steinle@eviden.com>", # @ammernico
+  "Michael Weiss <michael.weiss@eviden.com>", # @primeos-work
 ]
 edition = "2021"
 rust-version = "1.70.0" # MSRV

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ cd /tmp/butido-test-repo
 - Original author: Matthias Beyer <mail@beyermatthias.de> @matthiasbeyer
 - Active maintainers: See `authors` in Cargo.toml
 - Passive maintainers
-  - Erdmut Pfeifer <erdmut.pfeifer@atos.net> @ErdmutPfeifer
-  - Christoph Prokop <christoph.prokop@atos.net> @christophprokop
+  - Erdmut Pfeifer <erdmut.pfeifer@eviden.com> @ErdmutPfeifer
+  - Christoph Prokop <christoph.prokop@eviden.com> @christophprokop
 
 
 # License


### PR DESCRIPTION
The migration(/split) to Eviden is still ongoing but the Eviden email addresses are the default for quite a while now (at least for external communication).

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
