### PR TITLE
Add a clippy allow exception to make CI happy/green

### DIFF
--- a/src/job/runnable.rs
+++ b/src/job/runnable.rs
@@ -50,6 +50,9 @@ pub struct RunnableJob {
 }
 
 impl RunnableJob {
+    // TODO: Drop the following clippy exception once we don't need to check against rustc 1.75
+    // anymore (a fix was already merged but it likely won't be backported to 1.75):
+    #[allow(clippy::map_identity)]
     pub fn build_from_job(
         job: &Job,
         source_cache: &SourceCache,


### PR DESCRIPTION
In bebe720, I already mentioned that there are two clippy warnings left and that a fix got merged - I just failed to realize that the fix probably won't be backported to the toolchain version 1.75 (given that the fix isn't that important as the lint only emits warnings by default and the flagged usage is probably not that common). Anyway, this makes the CI checks green again (they're currently red as an optional test fails - this test will also become required once version 1.75 hits the stable channel (unless the clippy fix would be backported before that)).

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
