### PR TITLE
Add a "release list" subcommand (alias for "db releases")

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -24,6 +24,33 @@ pub const IDENT_DEPENDENCY_TYPE_BUILD: &str = "build";
 pub const IDENT_DEPENDENCY_TYPE_RUNTIME: &str = "runtime";
 
 pub fn cli() -> Command {
+    let releases_list_command = Command::new("releases")
+        .about("List releases")
+        .arg(
+            Arg::new("csv")
+                .action(ArgAction::SetTrue)
+                .required(false)
+                .long("csv")
+                .help("Format output as CSV"),
+        )
+        .arg(arg_older_than_date("List only releases older than DATE"))
+        .arg(arg_newer_than_date("List only releases newer than DATE"))
+        .arg(
+            Arg::new("store")
+                .required(false)
+                .long("to")
+                .value_name("STORE")
+                .help("List only releases to STORE"),
+        )
+        .arg(
+            Arg::new("package")
+                .required(false)
+                .long("package")
+                .short('p')
+                .value_name("PKG")
+                .help("Only list releases for package PKG"),
+        );
+
     Command::new("butido")
         .author(crate_authors!())
         .disable_version_flag(true)
@@ -355,33 +382,7 @@ pub fn cli() -> Command {
                     .help("The id of the Job")
                 )
             )
-            .subcommand(Command::new("releases")
-                .about("List releases")
-                .arg(Arg::new("csv")
-                    .action(ArgAction::SetTrue)
-                    .required(false)
-                    .long("csv")
-                    .help("Format output as CSV")
-                )
-
-                .arg(arg_older_than_date("List only releases older than DATE"))
-                .arg(arg_newer_than_date("List only releases newer than DATE"))
-
-                .arg(Arg::new("store")
-                    .required(false)
-                    .long("to")
-                    .value_name("STORE")
-                    .help("List only releases to STORE")
-                )
-
-                .arg(Arg::new("package")
-                    .required(false)
-                    .long("package")
-                    .short('p')
-                    .value_name("PKG")
-                    .help("Only list releases for package PKG")
-                )
-            )
+            .subcommand(releases_list_command.clone())
         )
 
         .subcommand(Command::new("build")
@@ -827,6 +828,7 @@ pub fn cli() -> Command {
 
         .subcommand(Command::new("release")
             .about("Manage artifact releases")
+            .subcommand(releases_list_command.name("list"))
             .subcommand(Command::new("rm")
                 .about("Remove release artifacts")
                 .long_about(indoc::indoc!(r#"

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -824,7 +824,7 @@ fn log_of(conn_cfg: DbConnectionConfig<'_>, matches: &ArgMatches) -> Result<()> 
 }
 
 /// Implementation of the "db releases" subcommand
-fn releases(
+pub fn releases(
     conn_cfg: DbConnectionConfig<'_>,
     config: &Configuration,
     matches: &ArgMatches,

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -34,6 +34,9 @@ pub async fn release(
     matches: &ArgMatches,
 ) -> Result<()> {
     match matches.subcommand() {
+        Some(("list", matches)) => {
+            crate::commands::db::releases(db_connection_config, config, matches)
+        }
         Some(("new", matches)) => new_release(db_connection_config, config, matches).await,
         Some(("rm", matches)) => rm_release(db_connection_config, config, matches).await,
         Some((other, _matches)) => Err(anyhow!("Unknown subcommand: {}", other)),


### PR DESCRIPTION
The "butido release" command offers the subcommands "new" and "rm" but a subcommand to list all releases was missing as that functionality is available via the "butido db releases" command.
This isn't really intuitive so let's simply add "release list" as an "alias" of the "db releases" command by reusing the existing code.

This resolves #143.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
