### PR TITLE
Provide context when adding an edge to the package dependency DAG fails

### DIFF
--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -185,14 +185,14 @@ impl Dag {
         ) -> Result<()> {
             for (package, idx) in mappings {
                 get_package_dependencies(package, conditional_data)
-                    .and_then_ok(|(name, constr, kind)| {
+                    .and_then_ok(|(dep_name, dep_constr, dep_kind)| {
                         mappings
                             .iter()
-                            .filter(|(package, _)| {
-                                *package.name() == name && constr.matches(package.version())
+                            .filter(|(pkg, _)| {
+                                *pkg.name() == dep_name && dep_constr.matches(pkg.version())
                             })
                             .try_for_each(|(_, dep_idx)| {
-                                dag.add_edge(*idx, *dep_idx, kind.clone())
+                                dag.add_edge(*idx, *dep_idx, dep_kind.clone())
                                     .map(|_| ())
                                     .map_err(Error::from)
                             })
@@ -218,6 +218,7 @@ impl Dag {
             progress,
             conditional_data,
         )?;
+        trace!("Adding the dependency edges to the DAG for package {:?}", p);
         add_edges(&mappings, &mut dag, conditional_data)?;
         trace!("Finished building the package DAG");
 


### PR DESCRIPTION
This can happen when the package repository contains cyclic
dependencies. The DAG library would only emit `WouldCycle` as error
message, which isn't enough to trace down the cycle. This adds enough
context to find the final DAG edge that would complete the cycle, e.g.:
```
$ butido build -I deb12 tree 1.8.0
[...]
Error: build command failed

Caused by:
    0: Failed to add package dependency DAG edge from package "tree" (1.8.0) to dependency "vim" (9.0.2153)
    1: WouldCycle
```

This resolves #52.