### PR TITLE
Stop using result-inspect from Rust version 1.76 onwards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "resiter",
  "result-inspect",
  "rlimit",
+ "rustversion",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ reqwest        = { version = "0.11", features = [ "stream" ] }
 resiter        = "0.5"
 result-inspect = "0.3"
 rlimit         = "0.10"
+rustversion    = "1"
 semver         = { version = "1", features = [ "serde" ] }
 serde          = "1"
 serde_json     = "1"

--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -19,6 +19,7 @@ use anyhow::Error;
 use anyhow::Result;
 use futures::FutureExt;
 use getset::{CopyGetters, Getters};
+#[rustversion::before(1.76)]
 use result_inspect::ResultInspect;
 use shiplift::Container;
 use shiplift::Docker;

--- a/src/filestore/staging.rs
+++ b/src/filestore/staging.rs
@@ -16,6 +16,7 @@ use anyhow::Error;
 use anyhow::Result;
 use futures::stream::Stream;
 use indicatif::ProgressBar;
+#[rustversion::before(1.76)]
 use result_inspect::ResultInspect;
 use tracing::trace;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,9 @@ use anyhow::Error;
 use anyhow::Result;
 use aquamarine as _;
 use clap::ArgMatches;
+// TODO: Drop the rust-inspect dependency once we bump the MSRV to 1.76:
+#[rustversion::since(1.76)]
+use result_inspect as _;
 use tracing::{debug, error};
 
 mod cli;


### PR DESCRIPTION
This is required to fix "cargo check" with Rust version 1.76+ (currently in the beta channel) while still supporting older toolchain versions.

The `std::result::Result::inspect` method used to be a nightly-only experimental API [0] but got stabilized in Rust version 1.76 [1] so we don't need to depend on the `result-inspect` crate anymore (we could make it optional but let's just wait until we bump the MSRV accordingly and drop it entirely).

[0]: https://doc.rust-lang.org/1.74.0/std/result/enum.Result.html#method.inspect
[1]: https://doc.rust-lang.org/beta/std/result/enum.Result.html#method.inspect

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---

This is required to unblock merging (the failing cargo-check CI test is required, even with the beta toolchain). It fixes the following errors:
```
error: unused import: `result_inspect::ResultInspect`
  --> src/endpoint/configured.rs:22:5
   |
22 | use result_inspect::ResultInspect;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> src/main.rs:37:5
   |
37 |     unused_imports,
   |     ^^^^^^^^^^^^^^

error: unused import: `result_inspect::ResultInspect`
  --> src/filestore/staging.rs:19:5
   |
19 | use result_inspect::ResultInspect;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `butido` (bin "butido") due to 2 previous errors
```
