### PR TITLE
actions: Only pin the checkout action to a major version

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -58,7 +58,7 @@ jobs:
           - beta
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -85,7 +85,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}
@@ -105,7 +105,7 @@ jobs:
           - rust: beta
             optional: true
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5


### PR DESCRIPTION
The `actions/checkout` action is from a trusted source (official GitHub Actions), this is in line with the documentation/examples [0], and it enables us to automatically get useful updates [1]:
> If the action publishes major version tags, you should expect to
receive critical fixes and security patches while still retaining compatibility. Note that this behavior is at the discretion of the action's author.

This especially makes sense since we already use this approach for all other included actions [2] (so it's finally consistent as well!). (Note: For 3rd-party actions it could make sense to use a more secure approach (commit SHA) but we don't need any secrets for CI and the sources should be trustable so our current approach should be fine.)

[0]: https://github.com/actions/checkout/blob/v4/README.md
[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
[2]: See `git grep -hoE '[^ ]+@[^ ]+' -- .github/workflows/ | sort -u`

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->

---

See https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions regarding security considerations.
