### PR TITLE
Replace the deprecated sha-1 crate with sha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha-1",
+ "sha1",
  "sha2",
  "shiplift",
  "syntect",
@@ -2143,10 +2143,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rustversion = "1"
 semver = { version = "1", features = [ "serde" ] }
 serde = "1"
 serde_json = "1"
-sha-1 = "0.10"
+sha1 = "0.10"
 sha2 = "0.10"
 shiplift = "0.7"
 syntect = "5"


### PR DESCRIPTION
The `sha-1` crate doesn't get updated anymore and the `sha1` crate should be used instead (the crate only got renamed [1]) [0]:
> This crate is deprecated! Use the sha1 crate instead.

Note: The `sha-1` crate is currently stuck at `v0.10.1` despite the following claim to update it until v0.11:
> The SHA-1 implementation was previously published as sha-1, but
> migrated to sha1 since v0.10.0. sha-1 will continue to receive v0.10.x
> patch updates, but will be deprecated after sha1 v0.11 release.

[0]: https://crates.io/crates/sha-1
[1]: https://github.com/RustCrypto/hashes/pull/350

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
