### PR TITLE
Make the config versioning/compatibility independent of the butido version and improve the config checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Upcoming
+
+### Major/Breaking changes
+
+* The format of the `compatibility` setting has changed from a string
+  (`semver::VersionReq`) to a number (`u16`) and needs to be updated to `1`.
+
 ## v0.4.0
 
 This release contains breaking changes. The relevant changes are listed in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## Configuration changes
+
+All configuration changes are documented in [CHANGELOG.toml](./CHANGELOG.toml).
+Butido should automatically output the relevant changes when the configuration
+is too old (i.e., must be updated).
+
 ## Upcoming
 
 ### Major/Breaking changes
 
-* The format of the `compatibility` setting has changed from a string
-  (`semver::VersionReq`) to a number (`u16`) and needs to be updated to `1`.
+* The configuration must be updated, see `CHANGELOG.toml` for details.
 
 ## v0.4.0
 

--- a/CHANGELOG.toml
+++ b/CHANGELOG.toml
@@ -1,0 +1,4 @@
+# Each key-value mapping is a changelog entry (configuration version -> required changes):
+0 = "This version was never used"
+1 = """The format of the `compatibility` setting has changed from a string \
+(`semver::VersionReq`) to a number (`u16`)."""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,6 @@ dependencies = [
  "result-inspect",
  "rlimit",
  "rustversion",
- "semver",
  "serde",
  "serde_json",
  "sha-1",
@@ -2079,15 +2078,6 @@ checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ resiter = "0.5"
 result-inspect = "0.3"
 rlimit = "0.10"
 rustversion = "1"
-semver = { version = "1", features = [ "serde" ] }
 serde = "1"
 serde_json = "1"
 sha-1 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ tar = "0.4"
 terminal_size = "0.3"
 tokio = { version = "1", features = ["macros", "fs", "process", "io-util", "time"] }
 tokio-stream = "0.1"
+toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 typed-builder = "0.18"
@@ -79,9 +80,6 @@ uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"
 which = "5"
 xdg = "2"
-
-[dev-dependencies]
-toml = "0.8"
 
 [build-dependencies]
 anyhow = "1"

--- a/config.toml
+++ b/config.toml
@@ -18,7 +18,7 @@ progress_format = "[{elapsed_precise}] ({percent:>3}%): {bar:40.cyan/blue} | {ms
 # The shebang line used when compiling the packaging scripts
 # Default if this value is not set is "#!/bin/bash".
 # Can be overwritten temporarily via CLI
-script_shebang = "#!/bin/bash"
+shebang = "#!/bin/bash"
 
 # The number of log lines to show if a build fails.
 # Defaults to 10

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 # Example configuration file for butido
 
 # Configuration and package definition compatibility
-compatibility = "0.4.0"
+compatibility = 1
 
 # Format of the progress bars used.
 # See https://docs.rs/indicatif/0.15.0/indicatif/#templates

--- a/examples/packages/repo/config.toml
+++ b/examples/packages/repo/config.toml
@@ -1,5 +1,5 @@
 # Example configuration file for butido
-compatibility = 0
+compatibility = 1
 script_highlight_theme = "Solarized (dark)"
 
 releases_root  = "/tmp/butido-test-releases"

--- a/examples/packages/repo/config.toml
+++ b/examples/packages/repo/config.toml
@@ -1,5 +1,5 @@
 # Example configuration file for butido
-compatibility = "0.1.0"
+compatibility = 0
 script_highlight_theme = "Solarized (dark)"
 
 releases_root  = "/tmp/butido-test-releases"

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -245,7 +245,7 @@ impl NotValidatedConfiguration {
         check_directory_exists(&self.staging_directory, "staging")?;
 
         // Error if releases_directory is not a directory
-        check_directory_exists(&self.releases_directory, "releases")?;
+        check_directory_exists(&self.releases_directory, "releases_root")?;
 
         if self.release_stores.is_empty() {
             return Err(anyhow!(
@@ -254,7 +254,7 @@ impl NotValidatedConfiguration {
         }
 
         // Error if source_cache_root is not a directory
-        check_directory_exists(&self.source_cache_root, "releases")?;
+        check_directory_exists(&self.source_cache_root, "source_cache")?;
 
         // Error if there are no phases configured
         if self.available_phases.is_empty() {

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -28,6 +28,7 @@ const CONFIGURATION_VERSION: u16 = 1;
 
 /// The configuration that is loaded from the filesystem
 #[derive(Debug, Getters, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NotValidatedConfiguration {
     /// Compatibility setting to check if the butido configuration from the user is compatible with
     /// the current butido version (this is kinda optional since the configuration is type checked

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -241,20 +241,17 @@ impl NotValidatedConfiguration {
             ));
         }
 
-        // Error if staging_directory is not a directory
-        check_directory_exists(&self.staging_directory, "staging")?;
-
-        // Error if releases_directory is not a directory
+        // Error if the configured directories are missing or no directories:
+        check_directory_exists(&self.log_dir, "log_dir")?;
         check_directory_exists(&self.releases_directory, "releases_root")?;
+        check_directory_exists(&self.staging_directory, "staging")?;
+        check_directory_exists(&self.source_cache_root, "source_cache")?;
 
         if self.release_stores.is_empty() {
             return Err(anyhow!(
                 "You need at least one release store in 'release_stores'"
             ));
         }
-
-        // Error if source_cache_root is not a directory
-        check_directory_exists(&self.source_cache_root, "source_cache")?;
 
         // Error if there are no phases configured
         if self.available_phases.is_empty() {

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -304,17 +304,28 @@ mod tests {
         }
     }
 
-    #[test]
-    // A test to ensure the example configuration file is up-to-date and valid
-    fn test_loading_example_configuration_file() {
+    // A helper function to load and validate butido configuration files:
+    fn test_loading_configuration_file(file_path: &str) {
         let mut config = config::Config::default();
         assert!(config
-            .merge(config::File::with_name("config.toml").required(true))
+            .merge(config::File::with_name(file_path).required(true))
             .is_ok());
         assert!(check_compatibility(&config).is_ok());
         let config = config.try_into::<NotValidatedConfiguration>();
         assert!(config.is_ok(), "Config loading failed: {config:?}");
         let config = config.unwrap().validate_config(true);
         assert!(config.is_ok(), "Config validation failed: {config:?}");
+    }
+
+    #[test]
+    // A test to ensure the example configuration file is up-to-date and valid
+    fn test_loading_example_configuration_file() {
+        test_loading_configuration_file("config.toml");
+    }
+
+    #[test]
+    // A test to ensure the example repo config file is up-to-date and valid
+    fn test_loading_example_repo_configuration_file() {
+        test_loading_configuration_file("examples/packages/repo/config.toml");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,11 +154,16 @@ async fn main() -> Result<()> {
 
     config.merge(::config::Environment::with_prefix("BUTIDO"))?;
 
+    // Check the "compatibility" setting before loading (type checking) the configuration so that
+    // we can better inform the users about required changes:
+    check_compatibility(&config)
+        .context("The butido configuration failed the compatibility check")?;
+
     let config = config
         .try_into::<NotValidatedConfiguration>()
-        .context("Failed to load Configuration object")?
+        .context("Failed to load (type check) the butido configuration")?
         .validate()
-        .context("Failed to validate configuration")?;
+        .context("Failed to validate the butido configuration")?;
 
     let hide_bars = cli.get_flag("hide_bars") || crate::util::stdout_is_pipe();
     let progressbars = ProgressBars::setup(config.progress_format().clone(), hide_bars);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
tl;dr:
- Version the butido configuration with integer numbers (vs. SemVer version requirements)
- Check if the config is compatible before trying to load (type check) it to improve the error messages
- Automatically output the required configuration changes (changelog) if updates are required
- Add tests for the example config files in this repo
- Fail with an error if there are unknown settings in the configuration
- Improve the checks for missing directories (one missing check + two wrong config key names)

Note: This makes breaking configuration changes that require users to update their configuration (should be trivial though as one only has to set `compatibility=1` and remove invalid settings, if present).

<details>
<summary>Example outputs</summary>

Before this PR:
```
$ butido build -I rh8 tree 1.8.0
Error: Failed to validate configuration

Caused by:
    Configuration is not compatible to butido 0.4.0
```

If config upgrades are required:
```
$ butido build -I rh8 tree 1.8.0
The butido configuration is too old and the following changes are required:
- Version 1: The format of the `compatibility` setting has changed from a string (`semver::VersionReq`) to a number (`u16`).
- Update the `compatibility` setting to `1`

Error: The butido configuration failed the compatibility check

Caused by:
    0: The expected configuration version is 1 while the provided configuration has a compatibility setting of 0
    1: The provided configuration is not compatible with this butido binary
```

Trying to load an old configuration:
```
$ butido build -I rh8 tree 1.8.0
Error: The butido configuration failed the compatibility check

Caused by:
    0: Set "compatibility" to 0 to get a summary of the required changes
    1: The format of the "compatibility" setting has changed from a string to a number
    2: Failed to parse the value of the compatibility setting (0.4.0) into a number (str -> u16)
    3: invalid digit found in string
```

Loading a configuration with invalid settings:
```
$ butido build -I rh8 tree 1.8.0
Error: Failed to load (type check) the butido configuration

Caused by:
    unknown field `invalid`, expected one of `compatibility`, `log_dir`, `strict_script_interpolation`, `progress_format`, `spinner_format`, `package_print_format`, `build_error_lines`, `script_highlight_theme`, `script_linter`, `shebang`, `releases_root`, `release_stores`, `staging`, `source_cache`, `database_host`, `database_port`, `database_user`, `database_password`, `database_name`, `database_connection_timeout`, `docker`, `containers`, `available_phases`
```

Invalid env vars:
```
$ BUTIDO_TEST=42 butido build -I rh8 tree 1.8.0
Error: Failed to load (type check) the butido configuration

Caused by:
    unknown field `test`, expected one of `compatibility`, `log_dir`, `strict_script_interpolation`, `progress_format`, `spinner_format`, `package_print_format`, `build_error_lines`, `script_highlight_theme`, `script_linter`, `shebang`, `releases_root`, `release_stores`, `staging`, `source_cache`, `database_host`, `database_port`, `database_user`, `database_password`, `database_name`, `database_connection_timeout`, `docker`, `containers`, `available_phases`
```
</details>