### PR TITLE
Add a test for loading the example packages repo and improve the `FileSystemRepresentation` code a bit

### DIFF
--- a/src/repository/fs/path.rs
+++ b/src/repository/fs/path.rs
@@ -54,11 +54,6 @@ impl TryFrom<&std::path::Component<'_>> for PathComponent {
 }
 
 impl PathComponent {
-    /// Helper fn whether this PathComponent is a PathComponent::PkgToml
-    pub fn is_pkg_toml(&self) -> bool {
-        std::matches!(self, PathComponent::PkgToml)
-    }
-
     /// Helper fn to get the directory name of this PathComponent if it is a PathComponent::DirName
     /// or None if it is not.
     pub fn dir_name(&self) -> Option<&str> {

--- a/src/repository/fs/representation.rs
+++ b/src/repository/fs/representation.rs
@@ -31,7 +31,7 @@ use crate::repository::fs::path::PathComponent;
 /// A type representing the filesystem
 ///
 /// This type can be used to load pkg.toml files from the filesystem. As soon as this object is
-/// loaded, all filesystem access is done and postprocessing of the loaded data can happen
+/// loaded, all filesystem access is done and postprocessing of the loaded data can happen.
 #[derive(Debug, getset::Getters)]
 pub struct FileSystemRepresentation {
     #[getset(get = "pub")]
@@ -44,7 +44,7 @@ pub struct FileSystemRepresentation {
 }
 
 impl FileSystemRepresentation {
-    /// Load the FileSystemRepresentation object starting a `root`.
+    /// Load the FileSystemRepresentation object starting at `root`.
     pub fn load(root: PathBuf) -> Result<Self> {
         let mut fsr = FileSystemRepresentation {
             root: root.clone(),
@@ -120,6 +120,7 @@ impl FileSystemRepresentation {
     /// # Example
     ///
     ///     /
+    ///     /pkg.toml <-- is not a leaf
     ///     /foo/
     ///     /foo/pkg.toml <-- is leaf
     ///     /bar/
@@ -170,15 +171,11 @@ impl FileSystemRepresentation {
         Ok(false)
     }
 
-    /// Get a Vec<(PathBuf, &String)> for the `path`
+    /// Get a Vec<(PathBuf, &String)> for the `path`.
     ///
     /// The result of this function is the trail of pkg.toml files from `self.root` to `path`,
     /// whereas the PathBuf is the actual path to the file and the `&String` is the content of the
     /// individual file.
-    ///
-    /// Merging all Strings in the returned Vec as Config objects should produce a Package. to
-    /// `path`, whereas the PathBuf is the actual path to the file and the `&String` is the content
-    /// of the individual file.
     ///
     /// Merging all Strings in the returned Vec as Config objects should produce a Package.
     pub fn get_files_for<'a>(&'a self, path: &Path) -> Result<Vec<(PathBuf, &'a String)>> {

--- a/src/repository/fs/representation.rs
+++ b/src/repository/fs/representation.rs
@@ -274,7 +274,7 @@ mod tests {
             // Representing
             //  /
             //  /foo
-            //  /foo/pkg.toml
+            //  /foo/pkg.toml: content
             elements: vec![dir("foo", vec![pkgtoml("content")])]
                 .into_iter()
                 .collect(),
@@ -300,8 +300,8 @@ mod tests {
             //  /
             //  /foo
             //  /foo/bar
-            //  /foo/baz
-            //  /foo/baz/pkg.toml
+            //  /foo/bar/baz
+            //  /foo/bar/baz/pkg.toml: content
             elements: vec![dir(
                 "foo",
                 vec![dir("bar", vec![dir("baz", vec![pkgtoml("content")])])],
@@ -329,9 +329,11 @@ mod tests {
             // Representing
             //  /
             //  /foo
+            //  /foo/pkg.toml: content1
             //  /foo/bar
-            //  /foo/baz
-            //  /foo/baz/pkg.toml
+            //  /foo/bar/pkg.toml: content2
+            //  /foo/bar/baz
+            //  /foo/bar/baz/pkg.toml: content3
             elements: vec![dir(
                 "foo",
                 vec![
@@ -385,9 +387,10 @@ mod tests {
             // Representing
             //  /
             //  /foo
+            //  /foo/pkg.toml: content1
             //  /foo/bar
-            //  /foo/baz
-            //  /foo/baz/pkg.toml
+            //  /foo/bar/baz
+            //  /foo/bar/baz/pkg.toml: content3
             elements: vec![dir(
                 "foo",
                 vec![
@@ -425,10 +428,11 @@ mod tests {
 
             // Representing
             //  /
+            //  /pkg.toml: content1
             //  /foo
             //  /foo/bar
-            //  /foo/baz
-            //  /foo/baz/pkg.toml
+            //  /foo/bar/baz
+            //  /foo/bar/baz/pkg.toml: content3
             elements: vec![
                 pkgtoml("content1"),
                 dir(

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -274,4 +274,32 @@ pub mod tests {
         assert_eq!(*p.version(), pversion("2"));
         assert!(!p.version_is_semver());
     }
+
+    #[test]
+    fn test_load_example_pkg_repo() -> Result<()> {
+        fn assert_pkg(repo: &Repository, name: &str, version: &str) {
+            let constraint =
+                PackageVersionConstraint::from_version(String::from("="), pversion(version));
+            let ps = repo.find_with_version(&pname(name), &constraint);
+            assert_eq!(ps.len(), 1, "Failed to find pkg: {name} ={version}");
+            let p = ps.first().unwrap();
+            assert_eq!(*p.name(), pname(name));
+            assert_eq!(*p.version(), pversion(version));
+            assert_eq!(p.sources().len(), 1);
+        }
+
+        let repo = Repository::load(
+            &PathBuf::from("examples/packages/repo/"),
+            &indicatif::ProgressBar::hidden(),
+        )?;
+
+        assert_pkg(&repo, "a", "1");
+        assert_pkg(&repo, "b", "2");
+        assert_pkg(&repo, "c", "3");
+        assert_pkg(&repo, "s", "19.0");
+        assert_pkg(&repo, "s", "19.1");
+        assert_pkg(&repo, "z", "26");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
Commits:
- Fix the comments for the `FileSystemRepresentation` tests
- Add a `FileSystemRepresentation` test for loading the example repo
- Drop two duplicate sentences from a `FileSystemRepresentation` comment
- Add comments for `FileSystemRepresentation` to make it easier to grasp
- Simplify the `FileSystemRepresentation` code a little
- Stop stripping the repo root prefix for `FileSystemRepresentation` files
- Add a test for loading the included example packages repository