### PR TITLE
Fix all clippy and rustc warnings (beta toolchain version 0.1.77)

### DIFF
--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -512,7 +512,6 @@ impl<'a> LogReceiver<'a> {
                     self.job.uuid()
                 ));
                 tokio::fs::OpenOptions::new()
-                    .create(true)
                     .create_new(true)
                     .write(true)
                     .open(&path)

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -221,6 +221,8 @@ impl<'a> std::fmt::Debug for DebugPackage<'a> {
 }
 
 impl PartialEq for Package {
+    // Ignore the following lint as it results in a false positive with clippy 0.1.77:
+    #[allow(clippy::unconditional_recursion)]
     fn eq(&self, other: &Package) -> bool {
         (self.name(), self.version()).eq(&(other.name(), other.version()))
     }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -135,7 +135,6 @@ impl SourceEntry {
 
         trace!("Creating file now: {}", p.display());
         tokio::fs::OpenOptions::new()
-            .create(true)
             .create_new(true)
             .write(true)
             .open(&p)


### PR DESCRIPTION
The `suspicious_open_options` lint [0] warns that the truncation behaviour should be made explicit when creating new files. We also set `create_new(true)`, which ensures that a new file will *always* be created so we should simply drop `create(true)` since it has no effect anyway: "If `.create_new(true)` is set, `.create()` and `.truncate()` are ignored." [1]

The `unconditional_recursion` lint [2] also emits a warning but that's a false positive and should already be fixed in nightly (see [3] for a very similar case and [4] for the PR that should fix it). In our case we're comparing tuples with just two fields of the `Package` structure so it isn't recursive.

[0]: https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options
[1]: https://docs.rs/tokio/1.34.0/tokio/fs/struct.OpenOptions.html#method.create_new
[2]: https://rust-lang.github.io/rust-clippy/master/index.html#/unconditional_recursion
[3]: https://github.com/rust-lang/rust-clippy/issues/12133
[4]: https://github.com/rust-lang/rust-clippy/pull/12137

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---
This fixes the following clippy warnings:
```
[rustup@groot butido]$ cargo clippy --release
   Compiling butido v0.4.0 (/home/rustup/butido)
warning: file opened with `create`, but `truncate` behavior not defined
   --> src/endpoint/scheduler.rs:515:22
    |
515 |                     .create(true)
    |                      ^^^^^^^^^^^^- help: add: `.truncate(true)`
    |
    = help: if you intend to overwrite an existing file entirely, call `.truncate(true)`
    = help: if you instead know that you may want to keep some parts of the old file, call `.truncate(false)`
    = help: alternatively, use `.append(true)` to append to the file instead of overwriting it
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_open_options
    = note: `#[warn(clippy::suspicious_open_options)]` on by default

warning: function cannot return without recursing
   --> src/package/package.rs:224:5
    |
224 | /     fn eq(&self, other: &Package) -> bool {
225 | |         (self.name(), self.version()).eq(&(other.name(), other.version()))
226 | |     }
    | |_____^
    |
note: recursive call site
   --> src/package/package.rs:225:9
    |
225 |         (self.name(), self.version()).eq(&(other.name(), other.version()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unconditional_recursion
    = note: `#[warn(clippy::unconditional_recursion)]` on by default

warning: file opened with `create`, but `truncate` behavior not defined
   --> src/source/mod.rs:138:14
    |
138 |             .create(true)
    |              ^^^^^^^^^^^^- help: add: `.truncate(true)`
    |
    = help: if you intend to overwrite an existing file entirely, call `.truncate(true)`
    = help: if you instead know that you may want to keep some parts of the old file, call `.truncate(false)`
    = help: alternatively, use `.append(true)` to append to the file instead of overwriting it
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_open_options

warning: `butido` (bin "butido") generated 3 warnings
    Finished release [optimized] target(s) in 12.57s
```