### PR TITLE
Merge security updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,9 +855,9 @@ checksum = "641b847f0375f4b2c595438eefc17a9c0fbf47b400cbdd1ad9332bf1e16b779d"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes 1.5.0",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,9 +1202,9 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
This fixes all current security issues that dependabot reported.
It replaces #338 and #344 (those PRs would be fine too but I prefer mentioning the security fixes in the commit messages - I'll check if the dependabot behavior can be configured to better mark security fixes).