### PR TITLE
Update the "config" crate (0.11 -> 0.14) and simply the package configuration merging logic for "patches"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.12.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
+checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
 dependencies = [
  "async-trait",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,17 +116,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2bee9b9ee0e5768772e38c07ef0ba23a490d7e1336ec7207c25712a2661c55"
 
 [[package]]
-name = "async-trait"
-version = "0.1.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.49",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,16 +400,15 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
 dependencies = [
- "async-trait",
  "lazy_static",
  "nom",
  "pathdiff",
  "serde",
- "toml 0.5.11",
+ "toml 0.8.10",
 ]
 
 [[package]]
@@ -2562,15 +2550,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,16 +110,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "ascii_table"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2bee9b9ee0e5768772e38c07ef0ba23a490d7e1336ec7207c25712a2661c55"
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
 
 [[package]]
 name = "autocfg"
@@ -406,12 +411,14 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+checksum = "54ad70579325f1a38ea4c13412b82241c5900700a69785d73e2736bd65a33f86"
 dependencies = [
+ "async-trait",
  "lazy_static",
  "nom",
+ "pathdiff",
  "serde",
  "toml 0.5.11",
 ]
@@ -1207,19 +1214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,13 +1393,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.3"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1598,6 +1597,12 @@ dependencies = [
  "structmeta",
  "syn 2.0.49",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
@@ -2271,12 +2276,6 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["cargo"] }
 clap_complete = "4"
 colored = "2"
-config = { version = "0.13", default-features = false, features = [ "toml" ] }
+config = { version = "0.14", default-features = false, features = [ "toml" ] }
 csv = "1"
 daggy = { version = "0.8", features = [ "serde" ] }
 dialoguer = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["cargo"] }
 clap_complete = "4"
 colored = "2"
-config = { version = "0.11", default-features = false, features = [ "toml" ] }
+config = { version = "0.12", default-features = false, features = [ "toml" ] }
 csv = "1"
 daggy = { version = "0.8", features = [ "serde" ] }
 dialoguer = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ chrono = "0.4"
 clap = { version = "4", features = ["cargo"] }
 clap_complete = "4"
 colored = "2"
-config = { version = "0.12", default-features = false, features = [ "toml" ] }
+config = { version = "0.13", default-features = false, features = [ "toml" ] }
 csv = "1"
 daggy = { version = "0.8", features = [ "serde" ] }
 dialoguer = "0.11"

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -9,6 +9,7 @@
 //
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 
 use getset::Getters;
@@ -97,6 +98,14 @@ impl Package {
             denied_images: None,
             phases: HashMap::new(),
             meta: None,
+        }
+    }
+
+    // A function to prepend the path of the base directory to the relative paths of the patches
+    // (it usually only makes sense to call this function once!):
+    pub fn set_patches_base_dir(&mut self, dir: &Path) {
+        for patch in self.patches.iter_mut() {
+            *patch = dir.join(patch.as_path());
         }
     }
 

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -13,3 +13,4 @@ mod repository;
 pub use repository::*;
 
 mod fs;
+mod pkg_toml_source;

--- a/src/repository/pkg_toml_source.rs
+++ b/src/repository/pkg_toml_source.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2024 science+computing ag and other contributors
+//
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+
+// A custom `Source` implementation for the `config` crate to tack the `pkg.toml` file path as URI/origin
+// in addition to the content (basically a replacement for `config::File::from_str(str, format)`).
+
+use std::path::Path;
+
+use config::ConfigError;
+use config::FileFormat;
+use config::Format;
+use config::Map;
+use config::Source;
+use config::Value;
+
+#[derive(Clone, Debug)]
+pub struct PkgTomlSource {
+    content: String,
+    uri: String,
+}
+
+impl PkgTomlSource {
+    pub fn new(path: &Path, content: String) -> Self {
+        // We could also use `path.to_str()` for proper error handling:
+        let path = path.to_string_lossy().to_string();
+        PkgTomlSource { content, uri: path }
+    }
+}
+
+impl Source for PkgTomlSource {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new((*self).clone())
+    }
+
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        FileFormat::Toml
+            .parse(Some(&self.uri), &self.content)
+            .map_err(|cause| ConfigError::FileParse {
+                uri: Some(self.uri.clone()),
+                cause,
+            })
+    }
+}

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -16,9 +16,6 @@ use anyhow::anyhow;
 use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
-use resiter::AndThen;
-use resiter::FilterMap;
-use resiter::Map;
 use tracing::trace;
 
 use crate::package::Package;
@@ -52,30 +49,6 @@ impl Repository {
         trace!("Loading files from filesystem");
         let fsr = FileSystemRepresentation::load(path.to_path_buf())?;
 
-        // Helper function to extract the `patches` array from a package config/definition:
-        fn get_patches(
-            config: &config::ConfigBuilder<config::builder::DefaultState>,
-            path: &Path,
-        ) -> Result<Vec<PathBuf>> {
-            // TODO: Avoid unnecessary config building (inefficient):
-            let config = config.build_cloned().context(anyhow!(
-                "Failed to load the following TOML file: {}",
-                path.display()
-            ))?;
-            match config.get_array("patches") {
-                Ok(v) => v
-                    .into_iter()
-                    .map(config::Value::into_string)
-                    .map_err(Error::from)
-                    .map_err(|e| e.context("patches must be strings"))
-                    .map_err(Error::from)
-                    .map_ok(PathBuf::from)
-                    .collect(),
-                Err(config::ConfigError::NotFound(_)) => Ok(Vec::with_capacity(0)),
-                Err(e) => Err(Error::from(e)),
-            }
-        }
-
         let leaf_files = fsr
             .files()
             .par_iter()
@@ -86,74 +59,69 @@ impl Repository {
                 Err(e) => Some(Err(e)),
             });
         progress.set_length(leaf_files.clone().count().try_into()?);
-        leaf_files.inspect(|r| trace!("Loading files for {:?}", r))
+        leaf_files
+            .inspect(|r| trace!("Loading files for {:?}", r))
             .map(|path| {
                 progress.inc(1);
                 let path = path?;
-                fsr.get_files_for(path)?
+                let config = fsr.get_files_for(path)?
                     .iter()
+                    // Load all "layers":
                     .inspect(|(path, _)| trace!("Loading layer at {}", path.display()))
-                    .fold(Ok(Config::builder()) as Result<_>, |config, (path, content)| {
-                        let mut config = config?;
-
-                        let patches_before_merge = get_patches(&config, path)?;
-                        config = config.add_source(config::File::from_str(content, config::FileFormat::Toml));
-                        let patches_after_merge = get_patches(&config, path)?;
-
-                        // TODO: Get rid of the unnecessarily complex handling of the `patches` configuration setting:
-                        // Ideally this would be handled by the `config` crate (this is
-                        // already the case for all other "settings" but in this case we also need
-                        // to prepend the corresponding directory path).
-                        let patches = if patches_before_merge == patches_after_merge {
-                            patches_before_merge
-                        } else {
-                            // The patches have changed since the `config.merge()` of the next
-                            // `pkg.toml` file so we have to build the paths to the patch files
-                            // by prepending the path to the directory of the `pkg.toml` file since
-                            // `path` is only available in this "iteration".
-                            patches_after_merge
-                                .into_iter()
-                                // Prepend the path of the directory of the `pkg.toml` file to the name of the patch:
-                                .map(|p| if let Some(current_dir) = path.parent() {
-                                    Ok(current_dir.join(p))
-                                } else {
-                                    Err(anyhow!("Path should point to path with parent, but doesn't: {}", path.display()))
-                                })
-                                .inspect(|patch| trace!("Patch: {:?}", patch))
-                                // If the patch file exists, use it (as config::Value).
-                                // Otherwise we have an error here, because we're referring to a non-existing file:
-                                .and_then_ok(|patch| if patch.exists() {
-                                    Ok(Some(patch))
-                                } else {
-                                    Err(anyhow!("Patch does not exist: {}", patch.display()))
-                                        .with_context(|| anyhow!("The patch is declared here: {}", path.display()))
-                                })
-                                .filter_map_ok(|o| o)
-                                .collect::<Result<Vec<_>>>()?
-                        };
-
-                        trace!("Patches after postprocessing merge: {:?}", patches);
-                        let patches = patches
-                            .into_iter()
-                            .map(|p| p.display().to_string())
-                            .map(config::Value::from)
-                            .collect::<Vec<_>>();
-                        {
-                            // Update the `patches` configuration setting:
-                            let mut builder = Config::builder();
-                            builder = builder.set_default("patches", config::Value::from(patches))?;
-                            config = config.add_source(builder.build()?);
-                            // Ideally we'd use `config.set()` but that is a permanent override (so
-                            // subsequent `config.merge()` merges won't have an effect on
-                            // "patches"). There's also `config.set_once()` but that only lasts
-                            // until the next `config.merge()` and `config.set_default()` only sets
-                            // a default value.
-                        }
-                        Ok(config)
+                    .fold(Config::builder(), |config_builder, (path, content)| {
+                        use crate::repository::pkg_toml_source::PkgTomlSource;
+                        config_builder.add_source(PkgTomlSource::new(path, (*content).to_string()))
                     })
-                    .and_then(|c| c.build()?.try_deserialize::<Package>().map_err(Error::from)
-                        .with_context(|| anyhow!("Could not load package configuration: {}", path.display())))
-                    .map(|pkg| ((pkg.name().clone(), pkg.version().clone()), pkg))
+                    .build()?;
+
+                let patches_value = config.get_array("patches");
+                let mut pkg = config
+                    .try_deserialize::<Package>()
+                    .map_err(Error::from)
+                    .with_context(|| {
+                        anyhow!("Could not load package configuration: {}", path.display())
+                    })?;
+
+                if !pkg.patches().is_empty() {
+                    // We have to build the full relative paths to the patch files by
+                    // prepending the path to the directory of the `pkg.toml` file they've
+                    // been defined in so that they can be found later.
+                    let patches = patches_value.context(anyhow!(
+                        "Bug: Could not get the \"patches\" value for: {}",
+                        path.display()
+                    ))?;
+                    let first_patch_value = patches.first().ok_or(anyhow!(
+                        "Bug: Could not get the first \"patches\" entry for: {}",
+                        path.display()
+                    ))?;
+                    // Get the origin (path to the `pkg.toml` file) for the "patches"
+                    // setting (it must currently be the same for all array entries):
+                    let origin_path = first_patch_value.origin().map(PathBuf::from).ok_or(anyhow!(
+                        "Bug: Could not get the origin of the first \"patches\" entry for: {}",
+                        path.display()
+                    ))?;
+                    // Note: `parent()` only "Returns None if the path terminates in a root
+                    // or prefix, or if it’s the empty string." so this should never happen:
+                    let origin_dir_path = origin_path.parent().ok_or(anyhow!(
+                        "Bug: Could not get the origin's parent of the first \"patches\" entry for: {}",
+                        path.display()
+                    ))?;
+                    pkg.set_patches_base_dir(origin_dir_path);
+                    // Check if the patches exist:
+                    for patch in pkg.patches() {
+                        if !patch.exists() {
+                            return Err(anyhow!(
+                                "Patch does not exist: {}",
+                                patch.display()
+                            ))
+                            .with_context(|| {
+                                anyhow!("The patch is declared here: {}", path.display())
+                            });
+                        }
+                    }
+                }
+
+                Ok(((pkg.name().clone(), pkg.version().clone()), pkg))
             })
             .collect::<Result<BTreeMap<_, _>>>()
             .map(Repository::new)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
Now, all dependencies should finally be up-to-date \o/ :)

This should also make configuration error messages a bit nicer as the output now includes the content of the problematic line, e.g.:
```
---- repository::repository::tests::test_load_example_pkg_repo stdout ----
Error: TOML parse error at line 3, column 3
  |
3 |   ../foo.patch,
  |   ^
invalid array
expected `]`
 in examples/packages/repo/s/19.2/pkg.toml
```
Or:
```
[michael@groot packages]$ butido build -I rh8 tree
Error: Loading the repository

Caused by:
    TOML parse error at line 1, column 8
      |
    1 | name = tree
      |        ^
    invalid string
    expected `"`, `'`
     in tree/pkg.toml
```