### PR TITLE
Allow dependency names that start with a number (+ parsing regex cleanup)

### DIFF
--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -35,6 +35,11 @@ pub trait ParseDependency {
 }
 
 lazy_static! {
+    // The following regex could be simplified significantly since we basically only need the space
+    // (" ") for splitting name and version (and both shouldn't be empty) - the rest of the
+    // validation could and probably should be done when parsing `name` and `version` (can make the
+    // errors more precise and we avoid that the regex diverges from the rest of the validation as
+    // it's already the case):
     pub(in crate::package::dependency)  static ref DEPENDENCY_PARSING_RE: Regex =
         Regex::new("^(?P<name>[[:alnum:]][[:alnum:]._-]*) (?P<version>[*=><]?[[:alnum:]][[:alnum:][:punct:]]*)$").unwrap();
 }
@@ -149,5 +154,12 @@ mod tests {
         dep_parse_expect_err("a\\ =42");
         dep_parse_expect_err("a =.0");
         dep_parse_expect_err("a =");
+        dep_parse_expect_err("");
+        dep_parse_expect_err(" ");
+        // Not supported yet:
+        dep_parse_expect_err("a *");
+        dep_parse_expect_err("a >2");
+        dep_parse_expect_err("a <2");
+        dep_parse_expect_err("a 42");
     }
 }

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -36,7 +36,7 @@ pub trait ParseDependency {
 
 lazy_static! {
     pub(in crate::package::dependency)  static ref DEPENDENCY_PARSING_RE: Regex =
-        Regex::new("^(?P<name>[[:alnum:]]([[[:alnum:]]\\.\\-_])*) (?P<version>([\\*=><])?[[:alnum:]]([[[:alnum:]][[:punct:]]])*)$").unwrap();
+        Regex::new("^(?P<name>[[:alnum:]][[[:alnum:]]\\.\\-_]*) (?P<version>[\\*=><]?[[:alnum:]][[[:alnum:]][[:punct:]]]*)$").unwrap();
 }
 
 /// Helper function for the actual implementation of the ParseDependency trait.

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -36,7 +36,7 @@ pub trait ParseDependency {
 
 lazy_static! {
     pub(in crate::package::dependency)  static ref DEPENDENCY_PARSING_RE: Regex =
-        Regex::new("^(?P<name>[[:alpha:]]([[[:alnum:]]\\.\\-_])*) (?P<version>([\\*=><])?[[:alnum:]]([[[:alnum:]][[:punct:]]])*)$").unwrap();
+        Regex::new("^(?P<name>[[:alnum:]]([[[:alnum:]]\\.\\-_])*) (?P<version>([\\*=><])?[[:alnum:]]([[[:alnum:]][[:punct:]]])*)$").unwrap();
 }
 
 /// Helper function for the actual implementation of the ParseDependency trait.
@@ -135,6 +135,20 @@ mod tests {
         assert_eq!(
             c,
             PackageVersionConstraint::from_version(String::from("="), exact("0.123"))
+        );
+    }
+
+    #[test]
+    fn test_dependency_string_where_pkg_starts_with_number() {
+        let s = "7z =42";
+        let d = Dependency::from(String::from(s));
+
+        let (n, c) = d.parse_as_name_and_version().unwrap();
+
+        assert_eq!(n, name("7z"));
+        assert_eq!(
+            c,
+            PackageVersionConstraint::from_version(String::from("="), exact("42"))
         );
     }
 }

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -107,6 +107,15 @@ mod tests {
         );
     }
 
+    fn dep_parse_expect_err(dependency_specification: &'static str) {
+        let dep = Dependency::from(dependency_specification.to_string());
+        let result = dep.parse_as_name_and_version();
+        assert!(
+            result.is_err(),
+            "Should not be able to parse this input: {dependency_specification}"
+        );
+    }
+
     //
     // tests
     //
@@ -129,5 +138,16 @@ mod tests {
     #[test]
     fn test_dependency_string_where_pkg_starts_with_number() {
         dep_parse_test("7z", "42");
+    }
+
+    #[test]
+    fn test_complex_dependency_parsing() {
+        dep_parse_test("0ad_", "42");
+        dep_parse_test("2048-cli_0.0", "42");
+
+        dep_parse_expect_err("0] =42");
+        dep_parse_expect_err("a\\ =42");
+        dep_parse_expect_err("a =.0");
+        dep_parse_expect_err("a =");
     }
 }

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -36,7 +36,7 @@ pub trait ParseDependency {
 
 lazy_static! {
     pub(in crate::package::dependency)  static ref DEPENDENCY_PARSING_RE: Regex =
-        Regex::new("^(?P<name>[[:alnum:]][[[:alnum:]]\\.\\-_]*) (?P<version>[\\*=><]?[[:alnum:]][[[:alnum:]][[:punct:]]]*)$").unwrap();
+        Regex::new("^(?P<name>[[:alnum:]][[:alnum:]\\.\\-_]*) (?P<version>[\\*=><]?[[:alnum:]][[:alnum:][:punct:]]*)$").unwrap();
 }
 
 /// Helper function for the actual implementation of the ParseDependency trait.

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -84,12 +84,27 @@ mod tests {
     // helper functions
     //
 
-    fn name(s: &'static str) -> PackageName {
-        PackageName::from(String::from(s))
-    }
+    fn dep_parse_test(name: &'static str, version: &'static str) {
+        let name = name.to_string();
+        let version = version.to_string();
 
-    fn exact(s: &'static str) -> PackageVersion {
-        PackageVersion::from(String::from(s))
+        let dependency_specification = format!("{name} ={version}");
+        let dep = Dependency::from(dependency_specification.clone());
+        let (dep_name, dep_version_constraint) = dep.parse_as_name_and_version().unwrap();
+
+        let version_constraint = PackageVersionConstraint::from_version(
+            String::from("="),
+            PackageVersion::from(version),
+        );
+        assert_eq!(
+            dep_name,
+            PackageName::from(name),
+            "Name check failed for input: {dependency_specification}"
+        );
+        assert_eq!(
+            dep_version_constraint, version_constraint,
+            "Version constraint check failed for input: {dependency_specification}"
+        );
     }
 
     //
@@ -98,57 +113,21 @@ mod tests {
 
     #[test]
     fn test_dependency_conversion_1() {
-        let s = "vim =8.2";
-        let d = Dependency::from(String::from(s));
-
-        let (n, c) = d.parse_as_name_and_version().unwrap();
-
-        assert_eq!(n, name("vim"));
-        assert_eq!(
-            c,
-            PackageVersionConstraint::from_version(String::from("="), exact("8.2"))
-        );
+        dep_parse_test("vim", "8.2");
     }
 
     #[test]
     fn test_dependency_conversion_2() {
-        let s = "gtk15 =1b";
-        let d = Dependency::from(String::from(s));
-
-        let (n, c) = d.parse_as_name_and_version().unwrap();
-
-        assert_eq!(n, name("gtk15"));
-        assert_eq!(
-            c,
-            PackageVersionConstraint::from_version(String::from("="), exact("1b"))
-        );
+        dep_parse_test("gtk15", "1b");
     }
 
     #[test]
     fn test_dependency_string_with_punctuation() {
-        let s = "foo-bar1.2.3 =0.123";
-        let d = Dependency::from(String::from(s));
-
-        let (n, c) = d.parse_as_name_and_version().unwrap();
-
-        assert_eq!(n, name("foo-bar1.2.3"));
-        assert_eq!(
-            c,
-            PackageVersionConstraint::from_version(String::from("="), exact("0.123"))
-        );
+        dep_parse_test("foo-bar1.2.3", "0.123");
     }
 
     #[test]
     fn test_dependency_string_where_pkg_starts_with_number() {
-        let s = "7z =42";
-        let d = Dependency::from(String::from(s));
-
-        let (n, c) = d.parse_as_name_and_version().unwrap();
-
-        assert_eq!(n, name("7z"));
-        assert_eq!(
-            c,
-            PackageVersionConstraint::from_version(String::from("="), exact("42"))
-        );
+        dep_parse_test("7z", "42");
     }
 }

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -36,7 +36,7 @@ pub trait ParseDependency {
 
 lazy_static! {
     pub(in crate::package::dependency)  static ref DEPENDENCY_PARSING_RE: Regex =
-        Regex::new("^(?P<name>[[:alnum:]][[:alnum:]\\.\\-_]*) (?P<version>[\\*=><]?[[:alnum:]][[:alnum:][:punct:]]*)$").unwrap();
+        Regex::new("^(?P<name>[[:alnum:]][[:alnum:]._-]*) (?P<version>[*=><]?[[:alnum:]][[:alnum:][:punct:]]*)$").unwrap();
 }
 
 /// Helper function for the actual implementation of the ParseDependency trait.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
This supports dependencies where the package name starts with a digit and tries to simplify the regex a bit by dropping unnecessary syntax.