### PR TITLE
Avoid unnecessary warnings with older Clippy versions

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -101,7 +101,6 @@ jobs:
         include:
           - rust: 1.74.0 # MSRV
             optional: false
-            extra_opts: "-A unknown-lints"
           - rust: beta
             optional: true
     steps:
@@ -114,7 +113,7 @@ jobs:
         with:
           shared-key: "ci"
       - name: cargo clippy
-        run: cargo clippy --all-targets -- -D warnings ${{ matrix.extra_opts }}
+        run: cargo clippy --all-targets -- -D warnings
 
   # This "accumulation" job is used as the required CI check for PRs.
   # We could require multiple jobs but the MSRV is subject to change and makes

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -223,7 +223,7 @@ impl<'a> std::fmt::Debug for DebugPackage<'a> {
 impl PartialEq for Package {
     // Ignore the following lint as it results in a false positive with clippy 0.1.77
     // (TODO: drop this once we bump the MSRV to 1.78):
-    #[allow(clippy::unconditional_recursion)]
+    #[rustversion::attr(all(since(1.77), before(1.78)), allow(clippy::unconditional_recursion))]
     fn eq(&self, other: &Package) -> bool {
         (self.name(), self.version()).eq(&(other.name(), other.version()))
     }


### PR DESCRIPTION
In 80e0101, I first added a rule for a new Clippy lint (introduced in 1.73.0) to fix our optional CI check that lints with the beta toolchain. This would break the required CI check against the MSRV so I decided to allow unknown lints for that check in ef29d94. However, this isn't ideal as it only applies to the CI checks and still shows the warnings when developing or rather linting locally.
Luckily we can use the rustversion crate to make the Clippy lint overrides via attributes also depend on the Rust/toolchain version (this especially helps with cases like in 0556536 where the override is only required for a single toolchain version).
It's just a bit unfortunate that I cannot use `stable(1.77)` since that really only applies to stable versions and `1.77` is currently still a beta version (so I have to combine `all`, `since`, and `before` to produce a `version(1.77)`).

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
