### PR TITLE
Add optional tracing-chrome setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.10",
  "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
  "typed-builder",
  "unindent",
@@ -2647,6 +2648,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "496b3cd5447f7ff527bbbf19b071ad542a000adf297d4127078b4dfdb931f41a"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ tokio-stream = "0.1"
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-chrome = "0.7.1"
 typed-builder = "0.18"
 unindent = "0.2"
 url = { version = "2", features = ["serde"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,13 @@ pub fn cli() -> Command {
             .help("Detailed version output with build information")
         )
 
+        .arg(Arg::new("tracing-chrome")
+            .action(ArgAction::SetTrue)
+            .required(false)
+            .long("tracing-chrome")
+            .help("Generate a chrome compatible trace file")
+        )
+
         .arg(Arg::new("hide_bars")
             .action(ArgAction::SetTrue)
             .required(false)


### PR DESCRIPTION
This patch adds an optional flag `--tracing-chrome` which enables the tracing-chrome backend for traces which then generates a chrome://tracing compatible file.

---

Please check whether this works as desired before merging.