### PR TITLE
Fix all clippy and rustc warnings (beta toolchain version 0.1.78)

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.74.0 # MSRV
+          toolchain: 1.76.0 # MSRV
           components: rustfmt
 
       - name: Run cargo fmt
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.74.0 # MSRV
+          - 1.76.0 # MSRV
           - stable
           - beta
 
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.74.0 # MSRV
+          - 1.76.0 # MSRV
           - stable
           - beta
     steps:
@@ -99,7 +99,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - rust: 1.74.0 # MSRV
+          - rust: 1.76.0 # MSRV
             optional: false
           - rust: beta
             optional: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ dependencies = [
  "regex",
  "reqwest",
  "resiter",
- "result-inspect",
  "rlimit",
  "rustversion",
  "serde",
@@ -1983,12 +1982,6 @@ name = "resiter"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc95d56eb1865f69288945759cc0879d60ee68168dce676730275804ad2b276"
-
-[[package]]
-name = "result-inspect"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a950f8ecfa2029aec35fed979f0a412e593926f67bf771f7b98509b08db160"
 
 [[package]]
 name = "rlimit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
   "Michael Weiss <michael.weiss@eviden.com>", # @primeos-work
 ]
 edition = "2021"
-rust-version = "1.74.0" # MSRV
+rust-version = "1.76.0" # MSRV
 license = "EPL-2.0"
 
 description = "Linux package tool utilizing Docker, PostgreSQL, and TOML"
@@ -57,7 +57,6 @@ rayon = "1"
 regex = "1"
 reqwest = { version = "0.11", features = [ "stream" ] }
 resiter = "0.5"
-result-inspect = "0.3"
 rlimit = "0.10"
 rustversion = "1"
 serde = "1"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Building butido is easy, assuming you have a Rust installation:
 cargo build --release # (remove --release for a debug build)
 ```
 
-Butido is built and tested with Rust 1.74.0 as MSRV.
+Butido is built and tested with Rust 1.76.0 as MSRV.
 
 
 ### (Development) Setup

--- a/src/commands/env_of.rs
+++ b/src/commands/env_of.rs
@@ -10,8 +10,6 @@
 
 //! Implementation of the 'env-of' subcommand
 
-use std::convert::TryFrom;
-
 use anyhow::Result;
 use clap::ArgMatches;
 use tracing::trace;

--- a/src/commands/find_artifact.rs
+++ b/src/commands/find_artifact.rs
@@ -10,7 +10,6 @@
 
 //! Implementation of the 'find-artifact' subcommand
 
-use std::convert::TryFrom;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/commands/find_pkg.rs
+++ b/src/commands/find_pkg.rs
@@ -10,8 +10,6 @@
 
 //! Implementation of the 'find-pkg' subcommand
 
-use std::convert::TryFrom;
-
 use anyhow::Context;
 use anyhow::Result;
 use clap::ArgMatches;

--- a/src/commands/lint.rs
+++ b/src/commands/lint.rs
@@ -10,7 +10,6 @@
 
 //! Implementation of the 'lint' subcommand
 
-use std::convert::TryFrom;
 use std::path::Path;
 
 use anyhow::anyhow;

--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -9,7 +9,6 @@
 //
 
 use std::concat;
-use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/src/commands/source/mod.rs
+++ b/src/commands/source/mod.rs
@@ -10,7 +10,6 @@
 
 //! Implementation of the 'source' subcommand
 
-use std::convert::TryFrom;
 use std::io::Write;
 use std::path::PathBuf;
 

--- a/src/commands/tree_of.rs
+++ b/src/commands/tree_of.rs
@@ -10,8 +10,6 @@
 
 //! Implementation of the 'tree-of' subcommand
 
-use std::convert::TryFrom;
-
 use anyhow::Error;
 use anyhow::Result;
 use clap::ArgMatches;

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -298,7 +298,7 @@ mod tests {
         assert!(changelog.is_ok());
         let changelog = changelog.unwrap();
         for i in 0..=CONFIGURATION_VERSION {
-            assert!(changelog.get(&i.to_string()).is_some());
+            assert!(changelog.contains_key(&i.to_string()));
         }
     }
 

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -11,7 +11,6 @@
 use anyhow::Error;
 use anyhow::Result;
 use clap::ArgMatches;
-use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::Pool;

--- a/src/db/models/artifact.rs
+++ b/src/db/models/artifact.rs
@@ -17,7 +17,6 @@ use anyhow::Error;
 use anyhow::Result;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::db::models::Job;
 use crate::db::models::Release;

--- a/src/db/models/endpoint.rs
+++ b/src/db/models/endpoint.rs
@@ -11,7 +11,6 @@
 use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::config::EndpointName;
 use crate::schema::endpoints;

--- a/src/db/models/envvar.rs
+++ b/src/db/models/envvar.rs
@@ -11,7 +11,6 @@
 use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::schema::envvars;
 use crate::schema::envvars::*;

--- a/src/db/models/githash.rs
+++ b/src/db/models/githash.rs
@@ -12,7 +12,6 @@ use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::schema::githashes;
 use crate::schema::githashes::*;

--- a/src/db/models/image.rs
+++ b/src/db/models/image.rs
@@ -11,7 +11,6 @@
 use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::schema::images;
 use crate::schema::images::*;

--- a/src/db/models/job.rs
+++ b/src/db/models/job.rs
@@ -12,7 +12,6 @@ use anyhow::Context;
 use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 use tracing::trace;
 
 use crate::db::models::{Endpoint, Image, Package, Submit};

--- a/src/db/models/job_env.rs
+++ b/src/db/models/job_env.rs
@@ -10,7 +10,6 @@
 
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::db::models::EnvVar;
 use crate::db::models::Job;

--- a/src/db/models/package.rs
+++ b/src/db/models/package.rs
@@ -13,7 +13,6 @@ use std::ops::Deref;
 use anyhow::Error;
 use anyhow::Result;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::schema::packages;
 use crate::schema::packages::*;

--- a/src/db/models/releases.rs
+++ b/src/db/models/releases.rs
@@ -12,7 +12,6 @@ use anyhow::Error;
 use anyhow::Result;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::db::models::Artifact;
 use crate::db::models::ReleaseStore;

--- a/src/db/models/submit.rs
+++ b/src/db/models/submit.rs
@@ -13,7 +13,6 @@ use anyhow::Error;
 use anyhow::Result;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use diesel::PgConnection;
 
 use crate::db::models::GitHash;
 use crate::db::models::Image;

--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -19,8 +19,6 @@ use anyhow::Error;
 use anyhow::Result;
 use futures::FutureExt;
 use getset::{CopyGetters, Getters};
-#[rustversion::before(1.76)]
-use result_inspect::ResultInspect;
 use shiplift::Container;
 use shiplift::Docker;
 use shiplift::ExecContainerOptions;

--- a/src/filestore/staging.rs
+++ b/src/filestore/staging.rs
@@ -16,8 +16,6 @@ use anyhow::Error;
 use anyhow::Result;
 use futures::stream::Stream;
 use indicatif::ProgressBar;
-#[rustversion::before(1.76)]
-use result_inspect::ResultInspect;
 use tracing::trace;
 
 use crate::filestore::path::ArtifactPath;

--- a/src/log/parser.rs
+++ b/src/log/parser.rs
@@ -145,8 +145,6 @@ pub fn parser<'a>() -> PomParser<'a, u8, LogItem> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::Error;
-    use anyhow::Result;
 
     // Helper function for showing log item in error message in pretty
     fn prettify_item(e: &LogItem) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,6 @@ use anyhow::Error;
 use anyhow::Result;
 use aquamarine as _;
 use clap::ArgMatches;
-// TODO: Drop the rust-inspect dependency once we bump the MSRV to 1.76:
-#[rustversion::since(1.76)]
-use result_inspect as _;
 use tracing::{debug, error};
 
 mod cli;

--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -319,8 +319,6 @@ mod tests {
     use crate::package::Dependency;
     use crate::util::docker::ImageName;
 
-    use indicatif::ProgressBar;
-
     #[test]
     fn test_add_package() {
         let mut btree = BTreeMap::new();

--- a/src/package/dependency/build.rs
+++ b/src/package/dependency/build.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 
 use crate::package::dependency::condition::Condition;
 use crate::package::dependency::ParseDependency;
-use crate::package::dependency::StringEqual;
 use crate::package::PackageName;
 use crate::package::PackageVersionConstraint;
 
@@ -31,15 +30,6 @@ impl AsRef<str> for BuildDependency {
         match self {
             BuildDependency::Simple(name) => name,
             BuildDependency::Conditional { name, .. } => name,
-        }
-    }
-}
-
-impl StringEqual for BuildDependency {
-    fn str_equal(&self, s: &str) -> bool {
-        match self {
-            BuildDependency::Simple(name) => name == s,
-            BuildDependency::Conditional { name, .. } => name == s,
         }
     }
 }

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -76,7 +76,6 @@ pub(in crate::package::dependency) fn parse_package_dependency_string_into_name_
 mod tests {
     use super::*;
 
-    use crate::package::PackageName;
     use crate::package::PackageVersion;
 
     //

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -26,10 +26,6 @@ pub use runtime::*;
 
 pub mod condition;
 
-pub trait StringEqual {
-    fn str_equal(&self, s: &str) -> bool;
-}
-
 pub trait ParseDependency {
     fn parse_as_name_and_version(&self) -> Result<(PackageName, PackageVersionConstraint)>;
 }

--- a/src/package/dependency/mod.rs
+++ b/src/package/dependency/mod.rs
@@ -8,8 +8,6 @@
 // SPDX-License-Identifier: EPL-2.0
 //
 
-use std::convert::TryFrom;
-
 use anyhow::anyhow;
 use anyhow::Result;
 use lazy_static::lazy_static;

--- a/src/package/dependency/runtime.rs
+++ b/src/package/dependency/runtime.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 
 use crate::package::dependency::condition::Condition;
 use crate::package::dependency::ParseDependency;
-use crate::package::dependency::StringEqual;
 use crate::package::PackageName;
 use crate::package::PackageVersionConstraint;
 
@@ -38,15 +37,6 @@ impl AsRef<str> for Dependency {
         match self {
             Dependency::Simple(name) => name,
             Dependency::Conditional { name, .. } => name,
-        }
-    }
-}
-
-impl StringEqual for Dependency {
-    fn str_equal(&self, s: &str) -> bool {
-        match self {
-            Dependency::Simple(name) => name == s,
-            Dependency::Conditional { name, .. } => name == s,
         }
     }
 }

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -276,11 +276,7 @@ impl Dependencies {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::package::Dependencies;
-    use crate::package::HashType;
-    use crate::package::HashValue;
-    use crate::package::Source;
-    use crate::package::SourceHash;
+
     use url::Url;
 
     /// helper function for quick object construction

--- a/src/package/version.rs
+++ b/src/package/version.rs
@@ -51,7 +51,7 @@ impl PackageVersionConstraint {
     }
 }
 
-impl std::convert::TryFrom<String> for PackageVersionConstraint {
+impl TryFrom<String> for PackageVersionConstraint {
     type Error = anyhow::Error;
 
     fn try_from(s: String) -> Result<Self> {
@@ -59,7 +59,7 @@ impl std::convert::TryFrom<String> for PackageVersionConstraint {
     }
 }
 
-impl std::convert::TryFrom<&str> for PackageVersionConstraint {
+impl TryFrom<&str> for PackageVersionConstraint {
     type Error = anyhow::Error;
 
     fn try_from(s: &str) -> Result<Self> {

--- a/src/repository/fs/path.rs
+++ b/src/repository/fs/path.rs
@@ -8,7 +8,6 @@
 // SPDX-License-Identifier: EPL-2.0
 //
 
-use std::convert::TryFrom;
 use std::path::Component;
 
 use anyhow::anyhow;

--- a/src/repository/fs/representation.rs
+++ b/src/repository/fs/representation.rs
@@ -9,8 +9,6 @@
 //
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::convert::TryInto;
 use std::path::Path;
 use std::path::PathBuf;
 

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -91,7 +91,6 @@ mod tests {
     use std::collections::BTreeMap;
 
     use resiter::Filter;
-    use resiter::Map;
 
     use crate::package::tests::package;
     use crate::package::tests::pname;


### PR DESCRIPTION
The beta toolchain (1.78) now has improved detection of unused/dead code, notices redundant imports, checks for MSRV compatibility, and has a new `unnecessary_get_then_check` lint. This resolves all new warnings/errors to make CI green again.