### PR TITLE
Improve/fix our human-panic metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ cd /tmp/butido-test-repo
 
 # License
 
-butido was developed for science+computing ag (an Atos company).
+butido was developed for science + computing AG (an Atos company).
 
 License: EPL-2.0

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,9 @@ async fn main() -> Result<()> {
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION")
     )
-    .authors("science-computing ag, opensoftware <opensoftware@science-computing.de>")
-    .homepage("atos.net/de/deutschland/sc"));
+    .authors("science + computing AG, openSoftware <opensoftware@science-computing.de>")
+    .homepage("https://github.com/science-computing/butido")
+    .support("- Via https://github.com/science-computing/butido/issues or mail to opensoftware@science-computing.de"));
 
     let app = cli::cli();
     let cli = app.get_matches();


### PR DESCRIPTION
- `science-computing` was wrong - according to https://www.unternehmensregister.de/ it's `science + computing` (with spaces) and we should use "Aktiengesellschaft" or "AG" (uppercase).
- The Atos homepage isn't really useful and we already linked to the GitHub repository in `Cargo.toml` (`package.{homepage,repository}`).
  - Alternatively https://atos.net/s+c might be a better link until we have a redirect from the Eviden website.
- Utilize the new `Metadata` field `support`.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---

New output:
```
Well, this is embarrassing.

butido had a problem and crashed. To help us diagnose the problem you can send us a crash report.

We have generated a report file at "/tmp/report-c7c1368c-772d-431b-9016-40fa0b094cca.toml". Submit an issue or email with the subject of "butido Crash Report" and include the report as an attachment.

- Homepage: https://github.com/science-computing/butido
- Authors: science + computing AG, openSoftware <opensoftware@science-computing.de>

To submit the crash report:

- Via https://github.com/science-computing/butido/issues or mail to opensoftware@science-computing.de

We take privacy seriously, and do not perform any automated error collection. In order to improve the software, we rely on people to submit reports.

Thank you kindly!
```