### PR TITLE
Add a configuration setting for limiting the DB queries (default limit)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -204,7 +204,7 @@ pub fn cli() -> Command {
                     .long("limit")
                     .short('L')
                     .value_name("LIMIT")
-                    .help("Only list LIMIT artifacts")
+                    .help("List newest LIMIT artifacts (0=unlimited)")
                 )
             )
 
@@ -265,7 +265,7 @@ pub fn cli() -> Command {
                     .long("limit")
                     .short('L')
                     .value_name("LIMIT")
-                    .help("Only list LIMIT submits")
+                    .help("List newest LIMIT submits (0=unlimited)")
                 )
                 .arg(Arg::new("for-commit")
                     .required(false)
@@ -319,7 +319,7 @@ pub fn cli() -> Command {
                     .long("limit")
                     .short('L')
                     .value_name("LIMIT")
-                    .help("Only list newest LIMIT jobs instead of all")
+                    .help("List newest LIMIT jobs (0=unlimited)")
                 )
 
                 .arg(arg_older_than_date("List only jobs older than DATE"))

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -122,6 +122,12 @@ pub struct NotValidatedConfiguration {
     #[getset(get = "pub")]
     database_connection_timeout: Option<u16>,
 
+    /// The default limit for database queries (when listing tables with the `db` subcommand;
+    /// 0=unlimited (not recommended as it might result in OOM kills))
+    #[serde(default = "default_database_query_limit")]
+    #[getset(get = "pub")]
+    database_default_query_limit: usize,
+
     /// The configuration for the Docker endpoints and images
     #[getset(get = "pub")]
     docker: DockerConfig,

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -110,3 +110,9 @@ pub fn default_script_shebang() -> String {
 pub fn default_build_error_lines() -> usize {
     10
 }
+
+/// The default value for the number of results/rows that should be returned for DB queries that
+/// list things (LIMIT)
+pub fn default_database_query_limit() -> usize {
+    10
+}


### PR DESCRIPTION
It is very useful to have a default limit for DB queries that can return lots of results/matches. Without a limit, the listing of DB tables can take a long time and even result in OOM kills (the latter should ideally be avoidable via data streaming instead of allocating memory to store all results before outputting them, which would also help with the former - at least with the initial delay before the output starts). See also [0].

This adds a configuration setting for the default limit as it makes sense to support user/project specific default limits.

Signed-off-by: Michael Weiss <michael.weiss@eviden.com>

[0]: https://github.com/science-computing/butido/pull/323#issuecomment-1836754840

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
