### PR TITLE
Improve the parsing of CLI arguments via Clap

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,7 +57,7 @@ pub fn cli() -> Command {
                 .short('L')
                 .value_name("LIMIT")
                 .help("List newest LIMIT releases (0=unlimited)")
-                .value_parser(parse_usize),
+                .value_parser(clap::value_parser!(usize)),
         );
 
     Command::new("butido")
@@ -214,7 +214,7 @@ pub fn cli() -> Command {
                     .short('L')
                     .value_name("LIMIT")
                     .help("List newest LIMIT artifacts (0=unlimited)")
-                    .value_parser(parse_usize)
+                    .value_parser(clap::value_parser!(usize))
                 )
             )
 
@@ -276,7 +276,7 @@ pub fn cli() -> Command {
                     .short('L')
                     .value_name("LIMIT")
                     .help("List newest LIMIT submits (0=unlimited)")
-                    .value_parser(parse_usize)
+                    .value_parser(clap::value_parser!(usize))
                 )
                 .arg(Arg::new("for-commit")
                     .required(false)
@@ -331,7 +331,7 @@ pub fn cli() -> Command {
                     .short('L')
                     .value_name("LIMIT")
                     .help("List newest LIMIT jobs (0=unlimited)")
-                    .value_parser(parse_usize)
+                    .value_parser(clap::value_parser!(usize))
                 )
 
                 .arg(arg_older_than_date("List only jobs older than DATE"))
@@ -1111,7 +1111,7 @@ pub fn cli() -> Command {
                         .long("limit")
                         .value_name("LIMIT")
                         .help("Only list LIMIT processes for each container")
-                        .value_parser(parse_usize)
+                        .value_parser(clap::value_parser!(usize))
                     )
                 )
             )
@@ -1352,12 +1352,6 @@ fn parse_date_from_string(s: &str) -> std::result::Result<String, String> {
                 .map_err(|e| e.to_string())
                 .map(|_| ())
         })
-        .map(|_| s.to_owned())
-}
-
-fn parse_usize(s: &str) -> std::result::Result<String, String> {
-    usize::from_str(s)
-        .map_err(|e| e.to_string())
         .map(|_| s.to_owned())
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,7 +56,8 @@ pub fn cli() -> Command {
                 .long("limit")
                 .short('L')
                 .value_name("LIMIT")
-                .help("List newest LIMIT releases (0=unlimited)"),
+                .help("List newest LIMIT releases (0=unlimited)")
+                .value_parser(parse_usize),
         );
 
     Command::new("butido")
@@ -213,6 +214,7 @@ pub fn cli() -> Command {
                     .short('L')
                     .value_name("LIMIT")
                     .help("List newest LIMIT artifacts (0=unlimited)")
+                    .value_parser(parse_usize)
                 )
             )
 
@@ -274,6 +276,7 @@ pub fn cli() -> Command {
                     .short('L')
                     .value_name("LIMIT")
                     .help("List newest LIMIT submits (0=unlimited)")
+                    .value_parser(parse_usize)
                 )
                 .arg(Arg::new("for-commit")
                     .required(false)
@@ -328,6 +331,7 @@ pub fn cli() -> Command {
                     .short('L')
                     .value_name("LIMIT")
                     .help("List newest LIMIT jobs (0=unlimited)")
+                    .value_parser(parse_usize)
                 )
 
                 .arg(arg_older_than_date("List only jobs older than DATE"))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -208,6 +208,7 @@ pub fn cli() -> Command {
                     .short('J')
                     .value_name("JOB UUID")
                     .help("Print only artifacts for a certain job")
+                    .value_parser(uuid::Uuid::parse_str)
                 )
                 .arg(Arg::new("limit")
                     .required(false)
@@ -246,6 +247,7 @@ pub fn cli() -> Command {
                     .index(1)
                     .value_name("SUBMIT")
                     .help("The Submit to show details about")
+                    .value_parser(uuid::Uuid::parse_str)
                 )
             )
 
@@ -308,6 +310,7 @@ pub fn cli() -> Command {
                     .short('S')
                     .value_name("UUID")
                     .help("Only list jobs of a certain submit")
+                    .value_parser(uuid::Uuid::parse_str)
                 )
 
                 .arg(Arg::new("image")
@@ -370,6 +373,7 @@ pub fn cli() -> Command {
                     .index(1)
                     .value_name("UUID")
                     .help("The job to show")
+                    .value_parser(uuid::Uuid::parse_str)
                 )
 
                 .arg(Arg::new("show_log")
@@ -408,6 +412,7 @@ pub fn cli() -> Command {
                     .index(1)
                     .value_name("UUID")
                     .help("The id of the Job")
+                    .value_parser(uuid::Uuid::parse_str)
                 )
             )
             .subcommand(releases_list_command.clone())
@@ -897,6 +902,7 @@ pub fn cli() -> Command {
                     .index(1)
                     .value_name("SUBMIT")
                     .help("The submit uuid from which to release a package")
+                    .value_parser(uuid::Uuid::parse_str)
                 )
                 .arg(Arg::new("release_store_name")
                     .required(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,6 +110,7 @@ pub fn cli() -> Command {
                 Override the database port set via configuration.
                 Can also be overridden via environment 'BUTIDO_DATABASE_PORT', but this setting has precedence.
             "#))
+            .value_parser(clap::value_parser!(u16))
         )
         .arg(Arg::new("database_user")
             .required(false)
@@ -1035,6 +1036,7 @@ pub fn cli() -> Command {
                     .value_name("N")
                     .default_value("10")
                     .help("How often to ping")
+                    .value_parser(clap::value_parser!(u64))
                 )
                 .arg(Arg::new("ping_sleep")
                     .required(false)
@@ -1042,6 +1044,7 @@ pub fn cli() -> Command {
                     .value_name("N")
                     .default_value("1")
                     .help("How long to sleep between pings")
+                    .value_parser(clap::value_parser!(u64))
                 )
             )
             .subcommand(Command::new("stats")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,6 @@
 //
 
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use clap::crate_authors;
 use clap::Arg;
@@ -147,11 +146,12 @@ pub fn cli() -> Command {
             .required(false)
             .long("db-timeout")
             .value_name("TIMEOUT")
-            .help("Override the database connection timeout")
+            .help("Override the database connection timeout (in seconds)")
             .long_help(indoc::indoc!(r#"
                 Override the database connection timeout set via configuration.
                 Can also be overridden via environment 'BUTIDO_DATABASE_CONNECTION_TIMEOUT', but this setting has precedence.
             "#))
+            .value_parser(clap::value_parser!(u16))
         )
 
         .subcommand(Command::new("generate-completions")
@@ -834,6 +834,7 @@ pub fn cli() -> Command {
                     .long("timeout")
                     .value_name("TIMEOUT")
                     .help("Set timeout for download in seconds")
+                    .value_parser(clap::value_parser!(u64))
                 )
             )
             .subcommand(Command::new("of")
@@ -1069,7 +1070,7 @@ pub fn cli() -> Command {
                         .short('t')
                         .value_name("TIMEOUT")
                         .help("Timeout in seconds")
-                        .value_parser(parse_u64)
+                        .value_parser(clap::value_parser!(u64))
                     )
                 )
                 .subcommand(Command::new("list")
@@ -1153,7 +1154,8 @@ pub fn cli() -> Command {
                         .required(false)
                         .long("timeout")
                         .value_name("DURATION")
-                        .help("Timeout")
+                        .help("Timeout in seconds")
+                        .value_parser(clap::value_parser!(u64))
                     )
                 )
                 .subcommand(Command::new("exec")
@@ -1352,12 +1354,6 @@ fn parse_date_from_string(s: &str) -> std::result::Result<String, String> {
                 .map_err(|e| e.to_string())
                 .map(|_| ())
         })
-        .map(|_| s.to_owned())
-}
-
-fn parse_u64(s: &str) -> std::result::Result<String, String> {
-    u64::from_str(s)
-        .map_err(|e| e.to_string())
         .map(|_| s.to_owned())
 }
 

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -166,11 +166,7 @@ fn setup(conn_cfg: DbConnectionConfig<'_>) -> Result<()> {
 
 /// Helper function to get the LIMIT for DB queries based on the default value and CLI parameters
 fn get_limit(matches: &ArgMatches, default_limit: &usize) -> Result<i64> {
-    let limit = matches
-        .get_one::<String>("limit")
-        .map(|s| s.parse::<usize>())
-        .transpose()?
-        .unwrap_or(*default_limit);
+    let limit = *matches.get_one::<usize>("limit").unwrap_or(default_limit);
     if limit == 0 {
         Ok(i64::MAX)
     } else {

--- a/src/commands/endpoint.rs
+++ b/src/commands/endpoint.rs
@@ -70,16 +70,8 @@ async fn ping(
     config: &Configuration,
     progress_generator: ProgressBars,
 ) -> Result<()> {
-    let n_pings = matches
-        .get_one::<String>("ping_n")
-        .map(|s| s.parse::<u64>())
-        .transpose()?
-        .unwrap(); // safe by clap
-    let sleep = matches
-        .get_one::<String>("ping_sleep")
-        .map(|s| s.parse::<u64>())
-        .transpose()?
-        .unwrap(); // safe by clap
+    let n_pings = *matches.get_one::<u64>("ping_n").unwrap(); // safe by clap
+    let sleep = *matches.get_one::<u64>("ping_sleep").unwrap(); // safe by clap
     let endpoints = connect_to_endpoints(config, &endpoint_names).await?;
     let multibar = Arc::new({
         let mp = indicatif::MultiProgress::new();

--- a/src/commands/endpoint.rs
+++ b/src/commands/endpoint.rs
@@ -13,7 +13,6 @@
 use std::collections::HashMap;
 use std::io::Write;
 use std::ops::Deref;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -340,10 +339,7 @@ async fn containers_top(
     matches: &ArgMatches,
     config: &Configuration,
 ) -> Result<()> {
-    let limit = matches
-        .get_one::<String>("limit")
-        .map(|s| usize::from_str(s.as_ref()))
-        .transpose()?;
+    let limit = matches.get_one::<usize>("limit");
     let older_than_filter = crate::commands::util::get_date_filter("older_than", matches)?;
     let newer_than_filter = crate::commands::util::get_date_filter("newer_than", matches)?;
     let csv = matches.get_flag("csv");
@@ -398,7 +394,7 @@ async fn containers_top(
         .inspect(|(cid, _top)| trace!("Processing top of container: {}", cid))
         .map(|(container_id, top)| {
             let processes = if let Some(limit) = limit {
-                top.processes.into_iter().take(limit).collect()
+                top.processes.into_iter().take(*limit).collect()
             } else {
                 top.processes
             };

--- a/src/commands/endpoint.rs
+++ b/src/commands/endpoint.rs
@@ -451,10 +451,8 @@ async fn containers_stop(
     let newer_than_filter = crate::commands::util::get_date_filter("newer_than", matches)?;
 
     let stop_timeout = matches
-        .get_one::<String>("timeout")
-        .map(|s| s.parse::<u64>())
-        .transpose()?
-        .map(std::time::Duration::from_secs);
+        .get_one::<u64>("timeout")
+        .map(|s| std::time::Duration::from_secs(*s));
 
     let stats = connect_to_endpoints(config, &endpoint_names)
         .await?

--- a/src/commands/endpoint_container.rs
+++ b/src/commands/endpoint_container.rs
@@ -150,10 +150,8 @@ async fn stop(matches: &ArgMatches, container: Container<'_>) -> Result<()> {
     container
         .stop({
             matches
-                .get_one::<String>("timeout")
-                .map(|s| s.parse::<u64>())
-                .transpose()?
-                .map(std::time::Duration::from_secs)
+                .get_one::<u64>("timeout")
+                .map(|t| std::time::Duration::from_secs(*t))
         })
         .await
         .map_err(Error::from)

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -66,11 +66,7 @@ async fn new_release(
     debug!("Release called for: {:?} {:?}", pname, pvers);
 
     let pool = db_connection_config.establish_pool()?;
-    let submit_uuid = matches
-        .get_one::<String>("submit_uuid")
-        .map(|s| uuid::Uuid::parse_str(s.as_ref()))
-        .transpose()?
-        .unwrap(); // safe by clap
+    let submit_uuid = matches.get_one::<uuid::Uuid>("submit_uuid").unwrap(); // safe by clap
     debug!("Release called for submit: {:?}", submit_uuid);
 
     let submit = crate::schema::submits::dsl::submits

--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -205,11 +205,7 @@ pub async fn download(
     progressbars: ProgressBars,
 ) -> Result<()> {
     let force = matches.get_flag("force");
-    let timeout = matches
-        .get_one::<String>("timeout")
-        .map(|s| s.parse::<u64>())
-        .transpose()
-        .context("Parsing timeout argument to integer")?;
+    let timeout = matches.get_one::<u64>("timeout").copied();
     let cache = PathBuf::from(config.source_cache_root());
     let sc = SourceCache::new(cache);
     let pname = matches

--- a/src/config/not_validated.rs
+++ b/src/config/not_validated.rs
@@ -120,7 +120,8 @@ pub struct NotValidatedConfiguration {
 
     /// The database connection timeout in seconds
     #[getset(get = "pub")]
-    database_connection_timeout: Option<u16>,
+    #[serde(default = "default_database_connection_timeout")]
+    database_connection_timeout: u16,
 
     /// The default limit for database queries (when listing tables with the `db` subcommand;
     /// 0=unlimited (not recommended as it might result in OOM kills))

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -111,6 +111,11 @@ pub fn default_build_error_lines() -> usize {
     10
 }
 
+/// The default value for the database connection timeout (in seconds)
+pub fn default_database_connection_timeout() -> u16 {
+    30
+}
+
 /// The default value for the number of results/rows that should be returned for DB queries that
 /// list things (LIMIT)
 pub fn default_database_query_limit() -> usize {

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -61,10 +61,8 @@ impl<'a> DbConnectionConfig<'a> {
                 .get_one::<String>("database_host")
                 .unwrap_or_else(|| config.database_host()),
             database_port: {
-                cli.get_one::<String>("database_port")
-                    .map(|s| s.parse::<u16>())
-                    .transpose()?
-                    .unwrap_or_else(|| *config.database_port())
+                *cli.get_one::<u16>("database_port")
+                    .unwrap_or_else(|| config.database_port())
             },
             database_user: cli
                 .get_one::<String>("database_user")

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -74,12 +74,8 @@ impl<'a> DbConnectionConfig<'a> {
                 .get_one::<String>("database_name")
                 .unwrap_or_else(|| config.database_name()),
             database_connection_timeout: {
-                cli.get_one::<u16>("database_connection_timeout")
-                    .map(|x| *x)
-                    .unwrap_or_else(|| {
-                        // hardcoded default of 30 seconds database timeout
-                        config.database_connection_timeout().unwrap_or(30)
-                    })
+                *cli.get_one::<u16>("database_connection_timeout")
+                    .unwrap_or_else(|| config.database_connection_timeout())
             },
         })
     }

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -76,9 +76,8 @@ impl<'a> DbConnectionConfig<'a> {
                 .get_one::<String>("database_name")
                 .unwrap_or_else(|| config.database_name()),
             database_connection_timeout: {
-                cli.get_one::<String>("database_connection_timeout")
-                    .map(|s| s.parse::<u16>())
-                    .transpose()?
+                cli.get_one::<u16>("database_connection_timeout")
+                    .map(|x| *x)
                     .unwrap_or_else(|| {
                         // hardcoded default of 30 seconds database timeout
                         config.database_connection_timeout().unwrap_or(30)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
This moves the value parsing of CLI arguments to Clap instead of the function that implements the CLI command. The advantage is that we get much better error messages with appropriate context (while even making the code more compact). An example:

Before this PR:
```
$ butido db artifacts -J a
Error: invalid length: expected length 32 for simple format, found 1
```
With this PR:
```
$ butido db artifacts -J a
error: invalid value 'a' for '--job <JOB UUID>': invalid length: expected length 32 for simple format, found 1

For more information, try '--help'.
```

**Warning:** This could result in regressions (runtime panics) as the current code cannot be statically typechecked from the CLI definition to the argument usage but I've tried to be as careful as possible and everything should hopefully still be fine (regressions would be easy to fix but annoying nonetheless).