### PR TITLE
Fix the ASCII table rendering for data with colored strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,11 @@ name = "ascii_table"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2bee9b9ee0e5768772e38c07ef0ba23a490d7e1336ec7207c25712a2661c55"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "unicode-width",
+]
 
 [[package]]
 name = "async-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 anyhow = "1"
 aquamarine = "0.5"
-ascii_table = "4"
+ascii_table = { version = "4", features = ["color_codes", "wide_characters"] }
 bytesize = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["cargo"] }


### PR DESCRIPTION
The colored output works via control characters that are part of the strings that are put in the columns of the table. This resulted in an incorrect column length computation as the `color_codes` feature is required to correctly support terminal color codes. I decided to additionally enable `wide_characters` support in case we ever start using (or are already using?) wide characters [0] in the data/output (e.g., emojis). That feature only requires an additional dependency on `unicode-width` that is already in `Cargo.lock`.

Colors are, e.g., used in the output of "butido db submit $SUBMIT".

[0]: https://en.wikipedia.org/wiki/Wide_character

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
![image](https://github.com/science-computing/butido/assets/95224042/aa068265-b3a0-40dd-b77e-ab551e29cd0d)
