### PR TITLE
Improve the consistency and handling of "-I, --image" CLI arguments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -289,6 +289,7 @@ pub fn cli() -> Command {
                 )
                 .arg(Arg::new("image")
                     .required(false)
+                    .short('I')
                     .long("image")
                     .value_name("IMAGE")
                     .help("Limit listed submits to submits on IMAGE")
@@ -1100,6 +1101,7 @@ pub fn cli() -> Command {
 
                     .arg(Arg::new("filter_image")
                         .required(false)
+                        .short('I')
                         .long("image")
                         .value_name("IMAGE")
                         .help("List only containers of IMAGE")

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -84,7 +84,7 @@ pub async fn build(
             .unwrap_or_else(|| config.shebang().clone())
     });
 
-    let image_name_lookup = ImageNameLookup::create(config.docker().images());
+    let image_name_lookup = ImageNameLookup::create(config.docker().images())?;
     let image_name = matches
         .get_one::<String>("image")
         .map(|s| image_name_lookup.expand(s))

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -51,7 +51,7 @@ use crate::package::Shebang;
 use crate::repository::Repository;
 use crate::schema;
 use crate::source::SourceCache;
-use crate::util::docker::resolve_image_name;
+use crate::util::docker::ImageNameLookup;
 use crate::util::progress::ProgressBars;
 use crate::util::EnvironmentVariableName;
 
@@ -84,9 +84,10 @@ pub async fn build(
             .unwrap_or_else(|| config.shebang().clone())
     });
 
+    let image_name_lookup = ImageNameLookup::create(config.docker().images());
     let image_name = matches
         .get_one::<String>("image")
-        .map(|s| resolve_image_name(s, config.docker().images()))
+        .map(|s| image_name_lookup.expand(s))
         .unwrap()?; // safe by clap
 
     debug!("Getting repository HEAD");

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -499,7 +499,7 @@ fn jobs(
         sel = sel.filter(schema::submits::uuid.eq(submit_uuid))
     }
 
-    let image_name_lookup = ImageNameLookup::create(config.docker().images());
+    let image_name_lookup = ImageNameLookup::create(config.docker().images())?;
     if let Some(image_name) = matches
         .get_one::<String>("image")
         .map(|s| image_name_lookup.expand(s))
@@ -554,7 +554,7 @@ fn jobs(
 
     let limit = get_limit(matches, default_limit)?;
 
-    let image_name_lookup = ImageNameLookup::create(config.docker().images());
+    let image_name_lookup = ImageNameLookup::create(config.docker().images())?;
 
     let data = sel
         .order_by(schema::jobs::id.desc()) // required for the --limit implementation

--- a/src/commands/find_artifact.rs
+++ b/src/commands/find_artifact.rs
@@ -63,7 +63,7 @@ pub async fn find_artifact(
         .transpose()?
         .unwrap_or_default();
 
-    let image_name_lookup = ImageNameLookup::create(config.docker().images());
+    let image_name_lookup = ImageNameLookup::create(config.docker().images())?;
     let image_name = matches
         .get_one::<String>("image")
         .map(|s| image_name_lookup.expand(s))

--- a/src/commands/find_artifact.rs
+++ b/src/commands/find_artifact.rs
@@ -30,7 +30,7 @@ use crate::filestore::ReleaseStore;
 use crate::filestore::StagingStore;
 use crate::package::PackageVersionConstraint;
 use crate::repository::Repository;
-use crate::util::docker::resolve_image_name;
+use crate::util::docker::ImageNameLookup;
 use crate::util::progress::ProgressBars;
 
 /// Implementation of the "find_artifact" subcommand
@@ -63,9 +63,10 @@ pub async fn find_artifact(
         .transpose()?
         .unwrap_or_default();
 
+    let image_name_lookup = ImageNameLookup::create(config.docker().images());
     let image_name = matches
         .get_one::<String>("image")
-        .map(|s| resolve_image_name(s, config.docker().images()))
+        .map(|s| image_name_lookup.expand(s))
         .transpose()?;
 
     debug!(

--- a/src/commands/tree_of.rs
+++ b/src/commands/tree_of.rs
@@ -21,7 +21,7 @@ use crate::package::Dag;
 use crate::package::PackageName;
 use crate::package::PackageVersionConstraint;
 use crate::repository::Repository;
-use crate::util::docker::resolve_image_name;
+use crate::util::docker::ImageNameLookup;
 use crate::util::EnvironmentVariableName;
 
 /// Implementation of the "tree_of" subcommand
@@ -36,9 +36,10 @@ pub async fn tree_of(matches: &ArgMatches, repo: Repository, config: &Configurat
         .map(PackageVersionConstraint::try_from)
         .transpose()?;
 
+    let image_name_lookup = ImageNameLookup::create(config.docker().images());
     let image_name = matches
         .get_one::<String>("image")
-        .map(|s| resolve_image_name(s, config.docker().images()))
+        .map(|s| image_name_lookup.expand(s))
         .transpose()?;
 
     let additional_env = matches

--- a/src/commands/tree_of.rs
+++ b/src/commands/tree_of.rs
@@ -36,7 +36,7 @@ pub async fn tree_of(matches: &ArgMatches, repo: Repository, config: &Configurat
         .map(PackageVersionConstraint::try_from)
         .transpose()?;
 
-    let image_name_lookup = ImageNameLookup::create(config.docker().images());
+    let image_name_lookup = ImageNameLookup::create(config.docker().images())?;
     let image_name = matches
         .get_one::<String>("image")
         .map(|s| image_name_lookup.expand(s))


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
75af1a6 Support short image names for the "endpoint containers list" command
de8bf88 Support the short "-I" option for all CLI arguments that take an image
2f81bf2 Support short image names for the "db submits" command
b07c77e Shorten the image names in the "db submit" output (table)
6734d3c Turn the warnings for duplicate container images names into errors
260b4d7 Convert the image name lookup helper function into a struct+trait