### PR TITLE
Fix the error propagation of the "source download" command

### DIFF
--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -20,7 +20,7 @@ use clap::ArgMatches;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tokio_stream::StreamExt;
-use tracing::{debug, info, trace, warn};
+use tracing::{info, trace, warn};
 
 use crate::config::*;
 use crate::package::PackageName;
@@ -305,13 +305,12 @@ pub async fn download(
 
     if r.is_err() {
         progressbar.lock().await.error().await;
+        return r;
     } else {
         progressbar.lock().await.success().await;
     }
 
-    debug!("r = {:?}", r);
-
     super::verify(matches, config, repo, progressbars).await?;
 
-    r
+    Ok(())
 }


### PR DESCRIPTION
The additional source verification in 2f8034b introduced a regression by returning the source verification errors before the errors of the download operation (the download errors therefore get omitted and users get misleading errors that the sources are missing and that the verification did therefore fail).

This restores the proper error messages and avoids unnecessary source verification by returning errors of the download operation before triggering the verification.

We also don't need the debug output as we already return the errors and I've put `Ok(())` at the end to make it a bit more readable.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---

Before:
```
$ butido source download vim =9.0.1050
[00:00:03] (100%): ████████████████████████████████████████ | Repository loading finished                                                                                                             [00:00:00] (100%): ████████████████████████████████████████ | At least one download of 1 failed                                                                                                       [00:00:00] (100%): ████████████████████████████████████████ | Source verification failed                                                                                                              Error: Source missing: /srv/butido/sources/vim-9.0.1050/src.source

Error: source command failed

Caused by:
    At least one package failed with source verification
```

After:
```
$ butido source download vim =9.0.1050
[00:00:03] (100%): ████████████████████████████████████████ | Repository loading finished                                                                                                             [00:00:00] (100%): ████████████████████████████████████████ | At least one download of 1 failed                                                                                                       Error: source command failed

Caused by:
    0: Downloading "https://github.com/vim/vim/archive/refs/tags/v9.0.1050-42.tar.gz" failed
    1: Received HTTP status code "404 Not Found" but "200 OK" is expected for a successful download
```