### PR TITLE
Make the error on other task message red

### DIFF
--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -563,9 +563,9 @@ impl<'a> Drop for JobTask<'a> {
             // If there are dependencies, the error is probably from another task
             // If there are no dependencies, the error was caused by something else
             let errmsg = if self.jobdef.dependencies.is_empty() {
-                "error occurred"
+                "error occured".red()
             } else {
-                "inherited"
+                "error on other task".red()
             };
 
             let max_endpoint_name_length = self.scheduler.max_endpoint_name_length();


### PR DESCRIPTION
Will make it easier to spot it in the output.

Partially fixes #57

This is an older commit. CP tested it, was fine

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
