### PR TITLE
Remove deprecated deny.toml fields

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,27 +1,16 @@
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
-
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-allow = ["MPL-2.0"]
-
-# List of explictly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
-deny = []
-
-# The lint level for licenses considered copyleft
-copyleft = "deny"
-
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will only be approved if it is both OSI-approved *AND* FSF/Free
-# * either - The license will be approved if it is either OSI-approved *OR* FSF/Free
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF/Free
-# * fsf-only - The license will be approved if is FSF/Free *AND NOT* OSI-approved
-# * neither - The license will be denied if is FSF/Free *OR* OSI-approved
-allow-osi-fsf-free = "either"
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "EPL-2.0",
+    "MIT",
+    "MPL-2.0",
+    "Unicode-DFS-2016"
+]
 
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -48,16 +37,17 @@ allow = [
 deny = [
     # Each entry the name of a crate and a version range. If version is
     # not specified, all versions will be matched.
-    { name = "fuchsia-cprng" }
+    { crate = "fuchsia-cprng" }
 ]
 
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
 ]
 
-# Similarly to `skip` allows you to skip certain crates during duplicate detection,
-# unlike skip, it also includes the entire tree of transitive dependencies starting at
-# the specified crate, up to a certain depth, which is by default infinite
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
 skip-tree = [
 ]
 


### PR DESCRIPTION
The fields were deprecated in version 0.14.12. The new default
behavior for the fields are:

- `unlicensed = "deny"`
  New default: `deny`
- `copyleft = "deny"`
  New default: `deny`
- `allow-osi-fsf-free = "either"`
  New default: `neither`
> It doesn't matter if the license is OSI and/or FSF free, only if it is
in the allow (or exception) list.

Link to the 0.14.12 changelog:
https://github.com/EmbarkStudios/cargo-deny/blob/main/CHANGELOG.md#01412---2024-02-23

This pull request describes the changes and new default behavior in
more detail:
https://github.com/EmbarkStudios/cargo-deny/pull/611
> This is a follow-up to #606 that actually provides a way to remove the
deprecated fields and opt in to the new behavior until the fields are
removed and the new behavior becomes the only behavior.

Since version 0.16.0 having these fields errors out.
https://github.com/EmbarkStudios/cargo-deny/blob/main/CHANGELOG.md#0160---2024-08-02
> ... making the usage of the deprecated fields into errors.

The diff in the comments are changes from the current cargo deny
template.