### PR TITLE
Add support for generating dependency DOT graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "parse-display",
+ "petgraph",
  "pom",
  "ptree",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ indoc = "2"
 itertools = "0.13"
 lazy_static = "1"
 parse-display = "0.10"
+petgraph = "0.6"
 pom = "3"
 ptree = { version = "0.5", default-features = false }
 rand = "0.8"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1019,6 +1019,12 @@ pub fn cli() -> Command {
                     conditions on dependencies.
                 "#))
             )
+            .arg(Arg::new("dot")
+                .action(ArgAction::SetTrue)
+                .required(false)
+                .long("dot")
+                .help("Output the dependency DAG in the Graphviz DOT format")
+            )
         )
 
         .subcommand(Command::new("metrics")

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -100,7 +100,7 @@ impl Package {
         }
     }
 
-    pub fn display_name_version(self) -> String {
+    pub fn display_name_version(&self) -> String {
         format!("{} {}", self.name, self.version)
     }
 

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -100,6 +100,10 @@ impl Package {
         }
     }
 
+    pub fn display_name_version(self) -> String {
+        format!("{} {}", self.name, self.version)
+    }
+
     #[cfg(test)]
     pub fn set_dependencies(&mut self, dependencies: Dependencies) {
         self.dependencies = dependencies;


### PR DESCRIPTION
- New `--dot` argument for the `tree-of` command.
- Add `petgraph` as a dependency
  Decided to use Petgraph instead of graphviz-rust because it integrates
  with the daggy crate and looks better maintained.
- Using dotted lines for build dependencies.

Fixes #378