### PR TITLE
Update diesel from 2.2.2 to 2.2.3 (security update)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
+checksum = "65e13bab2796f412722112327f3e575601a3e9cdcbe426f0d30dbf43f3f5dc71"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",


### PR DESCRIPTION
This fixes the RUSTSEC-2024-0365 [0] security issue: "Binary Protocol Misinterpretation caused by Truncating or Overflowing Casts". See also GHSA-wq9x-qwcq-mmgf and [1].

[0]: https://rustsec.org/advisories/RUSTSEC-2024-0365.html
[1]: https://github.com/science-computing/butido/security/dependabot/17

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
