### PR TITLE
Add documentation links for cargo-deny and ignore that the yaml-rust crate is unmaintained

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -81,11 +81,12 @@ jobs:
           - advisories
           - bans licenses sources
 
-    # Prevent sudden announcement of a new advisory from failing ci:
+    # Prevent sudden announcement of a new advisory from failing CI:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
 
     steps:
       - uses: actions/checkout@v4
+      # https://github.com/EmbarkStudios/cargo-deny-action:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check ${{ matrix.checks }}

--- a/deny.toml
+++ b/deny.toml
@@ -59,4 +59,9 @@ skip-tree = [
 
 [advisories]
 ignore = [
+    # Ignore an "INFO Unmaintained" advisory for the yaml-rust crate that the
+    # "syntect" crate uses. This can be removed once
+    # https://github.com/trishume/syntect/issues/537 is resolved (replace
+    # yaml-rust with yaml-rust2):
+    { id = "RUSTSEC-2024-0320", reason = "Only an informative advisory that the crate is unmaintained and the maintainer unreachable" },
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,10 @@
+# Documentation for this configuration file:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+
+# GitHub link: https://github.com/EmbarkStudios/cargo-deny
+
 [licenses]
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
ef6053f Let cargo-deny ignore that the yaml-rust crate is unmaintained
87e967c Add documentation links for cargo-deny

This are basically optional follow-ups on #405 and #414.