### PR TITLE
Handle a new Rust/cargo-deny advisory that proc-macro-error is unmaintained

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,14 +918,14 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+checksum = "f636605b743120a8d32ed92fc27b6cde1a769f8f936c065151eb66f88ded513c"
 dependencies = [
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1978,6 +1978,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -64,4 +64,9 @@ ignore = [
     # https://github.com/trishume/syntect/issues/537 is resolved (replace
     # yaml-rust with yaml-rust2):
     { id = "RUSTSEC-2024-0320", reason = "Only an informative advisory that the crate is unmaintained and the maintainer unreachable" },
+    # Ignore an "INFO Unmaintained" advisory for the proc-macro-error crate
+    # that the "aquamarine" crate uses. This can be removed once
+    # https://github.com/mersinvald/aquamarine/issues/45 is resolved (Move away
+    # from proc-macro-error):
+    { id = "RUSTSEC-2024-0370", reason = "Only an informative advisory that the crate is unmaintained and the maintainer unreachable" },
 ]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
97bd303 Let cargo-deny ignore that the proc-macro-error crate is unmaintained
229de9c Update "getset" to get rid of the "proc-macro-error" dependency

I could get rid of the dependency for `getset` but there isn't an update for `aquamarine` yet.

From https://github.com/science-computing/butido/actions/runs/10818596028/job/30014565914?pr=407:
```
error[unmaintained]: proc-macro-error is unmaintained
    ┌─ /github/workspace/Cargo.lock:198:1
    │
198 │ proc-macro-error 1.0.4 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2024-0370
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0370
    ├ proc-macro-error's maintainer seems to be unreachable, with no commits for 2 years, no releases pushed for 4 years, and no activity on the GitLab repo or response to email.
      
      proc-macro-error also depends on `syn 1.x`, which may be bringing duplicate dependencies into dependant build trees.
      
      ## Possible Alternative(s)
      
      - [manyhow](https://crates.io/crates/manyhow)
      - [proc-macro-error2](https://crates.io/crates/proc-macro-error2)
      - [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)
    ├ Announcement: https://gitlab.com/CreepySkeleton/proc-macro-error/-/issues/[20](https://github.com/science-computing/butido/actions/runs/10818596028/job/30014565914?pr=407#step:4:21)
    ├ Solution: No safe upgrade is available!
    ├ proc-macro-error v1.0.4
      ├── aquamarine v0.5.0
      │   └── butido v0.5.0
      └── getset v0.1.2
          └── butido v0.5.0 (*)

advisories FAILED
```