### PR TITLE
Let the `download_manually` source property default to `false`

### DIFF
--- a/examples/packages/repo/pkg.toml
+++ b/examples/packages/repo/pkg.toml
@@ -7,7 +7,6 @@ runtime = []
 
 [sources.src]
 hash.type = "sha1"
-download_manually = false
 
 [phases]
 

--- a/src/package/source.rs
+++ b/src/package/source.rs
@@ -17,12 +17,20 @@ use serde::Serialize;
 use tracing::trace;
 use url::Url;
 
+fn default_download_manually() -> bool {
+    false
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Getters)]
 pub struct Source {
     #[getset(get = "pub")]
     url: Url,
     #[getset(get = "pub")]
     hash: SourceHash,
+
+    // This is only required for some special packages that cannot be downloaded automatically for
+    // various reasons so it defaults to `false`:
+    #[serde(default = "default_download_manually")]
     #[getset(get = "pub")]
     download_manually: bool,
 }


### PR DESCRIPTION
This is an optional setting that should only have to be set for sources that have to be downloaded manually. The example in `examples/packages/repo/pkg.toml` isn't a proper default as it only applies to the source "src" (packages could have multiples sources or choose a different name).

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
---

I noticed this yesterday with @ammernico.
The `hash.type = "sha1"` repo-wide "default" in `examples/packages/repo/pkg.toml` is also a bad idea IMO (in that case butido shouldn't provide a default but it should either be set explicitly for each package or we should encode the hash type in the field where we provide it [0]).

[0]: I.e. we could replace this:
```
hash.type = "sha256"
hash.hash = "73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
```
with this:
```
hash = "sha256-73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049"
```
(makes the Serde part a bit more complicated but we should be able to use a custom deserializer)