### PR TITLE
Cleanup running containers on the Control-C signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "terminal_size",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-chrome",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,8 @@ shiplift = "0.7"
 syntect = "5"
 tar = "0.4"
 terminal_size = "0.4"
-tokio = { version = "1", features = ["macros", "fs", "process", "io-util", "time"] }
+tokio = { version = "1", features = ["macros", "fs", "process", "io-util", "signal", "time"] }
+tokio-util = "0.7"
 tokio-stream = "0.1"
 toml = "0.8"
 tracing = "0.1"

--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -396,6 +396,7 @@ impl From<shiplift::rep::Image> for Image {
     }
 }
 
+#[derive(Clone)]
 pub struct EndpointHandle(Arc<Endpoint>);
 
 impl EndpointHandle {

--- a/src/job/runnable.rs
+++ b/src/job/runnable.rs
@@ -28,7 +28,7 @@ use crate::util::docker::ImageName;
 use crate::util::EnvironmentVariableName;
 
 /// A job configuration that can be run. All inputs are clear here.
-#[derive(Debug, Getters)]
+#[derive(Clone, Debug, Getters)]
 pub struct RunnableJob {
     #[getset(get = "pub")]
     uuid: Uuid,

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -13,6 +13,7 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -32,8 +33,9 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info, trace};
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -265,12 +267,26 @@ impl Borrow<ArtifactPath> for ProducedArtifact {
 
 impl Orchestrator<'_> {
     pub async fn run(self, output: &mut Vec<ArtifactPath>) -> Result<HashMap<Uuid, Error>> {
-        let (results, errors) = self.run_tree().await?;
+        let cancellation_token = CancellationToken::new();
+        let controlc_cancellation_token = cancellation_token.clone();
+
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c().await.unwrap();
+            info!("Received the Ctrl-c signal, stopping...");
+            controlc_cancellation_token.cancel();
+            ExitCode::from(1)
+        });
+
+        let (results, errors) = self.run_tree(cancellation_token).await?;
+
         output.extend(results);
         Ok(errors)
     }
 
-    async fn run_tree(self) -> Result<(Vec<ArtifactPath>, HashMap<Uuid, Error>)> {
+    async fn run_tree(
+        self,
+        token: CancellationToken,
+    ) -> Result<(Vec<ArtifactPath>, HashMap<Uuid, Error>)> {
         let prepare_span = tracing::debug_span!("run tree preparation");
 
         // There is no async code until we drop this guard, so this is fine
@@ -452,45 +468,55 @@ impl Orchestrator<'_> {
         // The JobTask::run implementation handles the rest, we just have to wait for all futures
         // to succeed.
         let run_span = tracing::debug_span!("run");
-        let running_jobs = jobs
-            .into_iter()
-            .map(|prep| {
-                trace!(parent: &run_span, job_uuid = %prep.1.jobdef.job.uuid(), "Creating JobTask");
-                // the sender is set or we need to use the root sender
-                let sender = prep
-                    .3
-                    .into_inner()
-                    .unwrap_or_else(|| vec![root_sender.clone()]);
-                JobTask::new(prep.0, prep.1, sender)
-            })
-            .inspect(
-                |task| trace!(parent: &run_span, job_uuid = %task.jobdef.job.uuid(), "Running job"),
-            )
-            .map(|task| {
-                task.run()
-                    .instrument(tracing::debug_span!(parent: &run_span, "JobTask::run"))
-            })
-            .collect::<futures::stream::FuturesUnordered<_>>();
-        debug!("Built {} jobs", running_jobs.len());
 
-        running_jobs
-            .collect::<Result<()>>()
-            .instrument(run_span.clone())
-            .await?;
-        trace!(parent: &run_span, "All jobs finished");
-        drop(run_span);
-
-        match root_receiver.recv().await {
-            None => Err(anyhow!("No result received...")),
-            Some(Ok(results)) => {
-                let results = results
-                    .into_iter()
-                    .flat_map(|tpl| tpl.1.into_iter())
-                    .map(ProducedArtifact::unpack)
-                    .collect();
-                Ok((results, HashMap::with_capacity(0)))
+        tokio::select! {
+            _ = token.cancelled() => {
+                anyhow::bail!("Received Control-C signal");
             }
-            Some(Err(errors)) => Ok((vec![], errors)),
+            r = async {
+                let running_jobs = jobs
+                        .into_iter()
+                        .map(|prep| {
+                            trace!(parent: &run_span, job_uuid = %prep.1.jobdef.job.uuid(), "Creating JobTask");
+                            // the sender is set or we need to use the root sender
+                            let sender = prep
+                                .3
+                                .into_inner()
+                                .unwrap_or_else(|| vec![root_sender.clone()]);
+                            JobTask::new(prep.0, prep.1, sender)
+                        })
+                        .inspect(
+                            |task| trace!(parent: &run_span, job_uuid = %task.jobdef.job.uuid(), "Running job"),
+                        )
+                        .map(|task| {
+                            task.run()
+                                .instrument(tracing::debug_span!(parent: &run_span, "JobTask::run"))
+                        })
+                        .collect::<futures::stream::FuturesUnordered<_>>();
+                debug!("Built {} jobs", running_jobs.len());
+
+                running_jobs
+                    .collect::<Result<()>>()
+                    .instrument(run_span.clone())
+                    .await?;
+                trace!(parent: &run_span, "All jobs finished");
+                drop(run_span);
+
+                match root_receiver.recv().await {
+                    None => Err(anyhow!("No result received...")),
+                    Some(Ok(results)) => {
+                        let results = results
+                            .into_iter()
+                            .flat_map(|tpl| tpl.1.into_iter())
+                            .map(ProducedArtifact::unpack)
+                            .collect();
+                        Ok((results, HashMap::with_capacity(0)))
+                    }
+                    Some(Err(errors)) => Ok((vec![], errors)),
+                }
+            } => {
+                r
+            }
         }
     }
 }


### PR DESCRIPTION
- Add the `signal` feature to `tokio` to interrupt and handle the Control-C signal in Butido.
- Add Control-C signal handling into the `Orchestrator`.
- Implement `Drop` on the `JobHandle` to ensure container cleanup.

This is a working draft pr for testing purposes and still missing some features.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
