### PR TITLE
Remove needless lifetimes to fix Clippy warnings

### DIFF
--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -40,7 +40,7 @@ pub struct DbConnectionConfig<'a> {
     database_connection_timeout: u16,
 }
 
-impl<'a> std::fmt::Debug for DbConnectionConfig<'a> {
+impl std::fmt::Debug for DbConnectionConfig<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,

--- a/src/filestore/path.rs
+++ b/src/filestore/path.rs
@@ -215,7 +215,7 @@ impl<'a> FullArtifactPath<'a> {
 #[derive(Debug)]
 pub struct FullArtifactPathDisplay<'a>(&'a StoreRoot, &'a ArtifactPath);
 
-impl<'a> std::fmt::Display for FullArtifactPathDisplay<'a> {
+impl std::fmt::Display for FullArtifactPathDisplay<'_> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(fmt, "{}/{}", self.0.display(), self.1.display())
     }

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -557,7 +557,7 @@ struct JobTask<'a> {
 /// runtime stops running it because some other `JobTask` errored.
 ///
 /// In the latter case, we cleanup by telling the progressbar to finish.
-impl<'a> Drop for JobTask<'a> {
+impl Drop for JobTask<'_> {
     fn drop(&mut self) {
         if !self.bar.is_finished() {
             // If there are dependencies, the error is probably from another task

--- a/src/orchestrator/util.rs
+++ b/src/orchestrator/util.rs
@@ -29,7 +29,7 @@ impl AsReceivedErrorDisplay for HashMap<Uuid, Error> {
 
 pub struct ReceivedErrorDisplay<'a>(&'a HashMap<Uuid, Error>);
 
-impl<'a> std::fmt::Display for ReceivedErrorDisplay<'a> {
+impl std::fmt::Display for ReceivedErrorDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0
             .iter()

--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -263,7 +263,7 @@ impl Dag {
 #[derive(Clone)]
 pub struct DagDisplay<'a>(&'a Dag, daggy::NodeIndex, Option<daggy::EdgeIndex>);
 
-impl<'a> TreeItem for DagDisplay<'a> {
+impl TreeItem for DagDisplay<'_> {
     type Child = Self;
 
     fn write_self<W: Write>(&self, f: &mut W, _: &Style) -> IoResult<()> {

--- a/src/package/package.rs
+++ b/src/package/package.rs
@@ -138,7 +138,7 @@ impl std::fmt::Debug for Package {
 pub struct DebugPackage<'a>(&'a Package);
 
 #[cfg(debug_assertions)]
-impl<'a> std::fmt::Debug for DebugPackage<'a> {
+impl std::fmt::Debug for DebugPackage<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         writeln!(
             f,

--- a/src/ui/package.rs
+++ b/src/ui/package.rs
@@ -108,7 +108,7 @@ pub fn handlebars_for_package_printing(format: &str) -> Result<Handlebars> {
     Ok(hb)
 }
 
-impl<'a, P: Borrow<Package>> PreparePrintPackage<'a, P> {
+impl<P: Borrow<Package>> PreparePrintPackage<'_, P> {
     pub fn into_displayable(self) -> Result<PrintablePackage> {
         let script = ScriptBuilder::new(&Shebang::from(self.config.shebang().clone()))
             .build(


### PR DESCRIPTION
The new needless_lifetimes lint [0], that got added in version 1.29.0, reported these lifetime annotations which can be removed by relying on lifetime elision.

This fixes our optional CI Clippy check with the beta toolchain.

[0]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
