### PR TITLE
deny.toml: Drop an exception for the unmaintained proc-macro-error crate

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -65,9 +65,4 @@ ignore = [
     # https://github.com/trishume/syntect/issues/537 is resolved (replace
     # yaml-rust with yaml-rust2):
     { id = "RUSTSEC-2024-0320", reason = "Only an informative advisory that the crate is unmaintained and the maintainer unreachable" },
-    # Ignore an "INFO Unmaintained" advisory for the proc-macro-error crate
-    # that the "aquamarine" crate uses. This can be removed once
-    # https://github.com/mersinvald/aquamarine/issues/45 is resolved (Move away
-    # from proc-macro-error):
-    { id = "RUSTSEC-2024-0370", reason = "Only an informative advisory that the crate is unmaintained and the maintainer unreachable" },
 ]


### PR DESCRIPTION
I added this exception in 97bd303 to make CI happy/green but we can now remove it again since the last update of the `aquamarine` crate in db00328 (#434).
The `aquamarine` crate switched to `proc-macro-error2` as well.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
