### PR TITLE
Fix two CI regressions (new beta toolchain lint and unmaintained crate advisory)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -65,4 +65,11 @@ ignore = [
     # https://github.com/trishume/syntect/issues/537 is resolved (replace
     # yaml-rust with yaml-rust2):
     { id = "RUSTSEC-2024-0320", reason = "Only an informative advisory that the crate is unmaintained and the maintainer unreachable" },
+
+    # Ignore an "INFO Unmaintained" advisory for the instant crate
+    # that the "indicatif" crate uses. This can be removed once
+    # https://github.com/console-rs/indicatif/issues/665 is resolved
+    # (The dependency instant is no longer maintained -
+    # consider switching to web-time instead):
+    { id = "RUSTSEC-2024-0384", reason = "Only an informative advisory that the crate is unmaintained and the author recommends using the maintained web-time crate instead." },
 ]

--- a/src/repository/repository.rs
+++ b/src/repository/repository.rs
@@ -277,7 +277,7 @@ impl Repository {
         pname: &'a Option<PackageName>,
         pvers: &'a Option<PackageVersionConstraint>,
         matching_regexp: &'a Option<Regex>,
-    ) -> Result<impl Iterator<Item = &Package> + 'a> {
+    ) -> Result<impl Iterator<Item = &'a Package> + 'a> {
         let mut r = self.inner.values()
         .filter(move |p| {
             match (pname, pvers, matching_regexp) {


### PR DESCRIPTION
Ignore an unmaintained crate deny check for now/Add a lifetime to an return type for the beta check