### PR TITLE
Remove needless lifetimes to fix Clippy warnings

### DIFF
--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -543,10 +543,7 @@ impl<'a> PreparedContainer<'a> {
         Ok(create_info)
     }
 
-    async fn copy_source_to_container<'ca>(
-        container: &Container<'ca>,
-        job: &RunnableJob,
-    ) -> Result<()> {
+    async fn copy_source_to_container(container: &Container<'_>, job: &RunnableJob) -> Result<()> {
         use tokio::io::AsyncReadExt;
 
         job.package_sources()
@@ -614,10 +611,7 @@ impl<'a> PreparedContainer<'a> {
             .map_err(Error::from)
     }
 
-    async fn copy_patches_to_container<'ca>(
-        container: &Container<'ca>,
-        job: &RunnableJob,
-    ) -> Result<()> {
+    async fn copy_patches_to_container(container: &Container<'_>, job: &RunnableJob) -> Result<()> {
         use tokio::io::AsyncReadExt;
 
         debug!(
@@ -672,8 +666,8 @@ impl<'a> PreparedContainer<'a> {
             .map_err(Error::from)
     }
 
-    async fn copy_artifacts_to_container<'ca>(
-        container: &Container<'ca>,
+    async fn copy_artifacts_to_container(
+        container: &Container<'_>,
         job: &RunnableJob,
         staging_store: Arc<RwLock<StagingStore>>,
         release_stores: &[Arc<ReleaseStore>],
@@ -777,10 +771,7 @@ impl<'a> PreparedContainer<'a> {
             .map(|_| ())
     }
 
-    async fn copy_script_to_container<'ca>(
-        container: &Container<'ca>,
-        script: &Script,
-    ) -> Result<()> {
+    async fn copy_script_to_container(container: &Container<'_>, script: &Script) -> Result<()> {
         let script_path = PathBuf::from(crate::consts::SCRIPT_PATH);
         container
             .copy_file_into(script_path, script.as_ref().as_bytes())
@@ -932,7 +923,7 @@ pub struct ExecutedContainer<'a> {
     exit_info: Option<(bool, Option<String>)>,
 }
 
-impl<'a> ExecutedContainer<'a> {
+impl ExecutedContainer<'_> {
     pub fn container_hash(&self) -> ContainerHash {
         ContainerHash::from(self.create_info.id.clone())
     }

--- a/src/endpoint/scheduler.rs
+++ b/src/endpoint/scheduler.rs
@@ -382,7 +382,7 @@ struct LogReceiver<'a> {
     bar: ProgressBar,
 }
 
-impl<'a> LogReceiver<'a> {
+impl LogReceiver<'_> {
     async fn join(mut self) -> Result<String> {
         let mut success = None;
         // Reserve a reasonable amount of elements.

--- a/src/orchestrator/orchestrator.rs
+++ b/src/orchestrator/orchestrator.rs
@@ -263,7 +263,7 @@ impl Borrow<ArtifactPath> for ProducedArtifact {
     }
 }
 
-impl<'a> Orchestrator<'a> {
+impl Orchestrator<'_> {
     pub async fn run(self, output: &mut Vec<ArtifactPath>) -> Result<HashMap<Uuid, Error>> {
         let (results, errors) = self.run_tree().await?;
         output.extend(results);


### PR DESCRIPTION
I already removed some needless lifetimes in 463111e but the needless_lifetimes lint [0] got improved again in Clippy version 0.1.84 (0f13036040 2024-11-30) so this commit drops additional lifetime annotations which can be removed by relying on lifetime elision.

This fixes our optional CI Clippy check with the beta toolchain.

[0]: https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
