### PR TITLE
Reland: Cleanup the logic for "merging" package "patches"

### DIFF
--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -13,3 +13,4 @@ mod repository;
 pub use repository::*;
 
 mod fs;
+mod pkg_toml_source;

--- a/src/repository/pkg_toml_source.rs
+++ b/src/repository/pkg_toml_source.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020-2024 science+computing ag and other contributors
+//
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+
+// A custom `Source` implementation for the `config` crate to tack the `pkg.toml` file path as URI/origin
+// in addition to the content (basically a replacement for `config::File::from_str(str, format)`).
+
+use std::path::Path;
+
+use config::ConfigError;
+use config::FileFormat;
+use config::Format;
+use config::Map;
+use config::Source;
+use config::Value;
+
+#[derive(Clone, Debug)]
+pub struct PkgTomlSource {
+    content: String,
+    uri: String,
+}
+
+impl PkgTomlSource {
+    pub fn new(path: &Path, content: String) -> Self {
+        // We could also use `path.to_str()` for proper error handling:
+        let path = path.to_string_lossy().to_string();
+        PkgTomlSource { content, uri: path }
+    }
+}
+
+impl Source for PkgTomlSource {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new((*self).clone())
+    }
+
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        FileFormat::Toml
+            .parse(Some(&self.uri), &self.content)
+            .map_err(|cause| ConfigError::FileParse {
+                uri: Some(self.uri.clone()),
+                cause,
+            })
+    }
+}


### PR DESCRIPTION
This is a reland of c88bad4 which I had to revert in 01f2ff7 since we had to downgrade the `config` crate (4c6f027). The reland is possible since we could upgrade the `config` crate to version 0.15 (9f05d6a) in the meantime. I cherry-picked c88bad4 but had to manually merge in the changes from 55920b5 and 97f0cee as well.

See below for the original commit message:

The old logic was pretty complex and only necessary to build the correct relative paths to the patch files (the paths in `pkg.toml` must be prepended with the relative path to the directory containing the `pkg.toml` file).
Since the recently released version 0.14.0 of the `config` crate we can access the "origin" of a configuration value (`Value::origin()`) so we can use that information to avoid having to check if the `patches` have changed every time we merge another `pkg.toml` file.

Unfortunately this does currently require a dedicated source implementation (`PkgTomlSource` but actually why not) since `config::File::from_str()` always sets the URI/origin to `None` and the new `set_patches_base_dir()` function is a bit of a hack... IMO the new code is much more readable, more efficient, and overall still cleaner though (most of the new code is for error handling and the custom `Source` implementation).

[0]: https://github.com/mehcode/config-rs/blob/0.14.0/CHANGELOG.md#0140---2024-02-01

Signed-off-by: Michael Weiss <michael.weiss@eviden.com>
(cherry picked from commit c88bad4fb30e2146691329ada0e4621d05b26512)

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
