### PR TITLE
Replace the `daggy` crate with `petgraph`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,6 @@ dependencies = [
  "colored",
  "config",
  "csv",
- "daggy",
  "dialoguer",
  "diesel",
  "diesel_migrations",
@@ -525,16 +524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "daggy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a9304e55e9d601a39ae4deaba85406d5c0980e106f65afcf0460e9af1e7602"
-dependencies = [
- "petgraph",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ clap_complete = "4"
 colored = "2"
 config = { version = "0.15", default-features = false, features = [ "toml" ] }
 csv = "1"
-daggy = { version = "0.8", features = [ "serde" ] }
 dialoguer = "0.11"
 diesel = { version = "2", features = ["postgres", "chrono", "uuid", "serde_json", "r2d2"] }
 diesel_migrations = "2"


### PR DESCRIPTION
The `daggy` crate doesn't seem maintained anymore as the last commit was over three years ago [0] and there isn't really any activity since then.

Daggy is already based on top of `petgraph` and described as follows:
> The most prominent type is Dag - a wrapper around petgraph’s Graph
> data structure, exposing a refined API targeted towards directed
> acyclic graph related functionality.

This means that we can switch directly to `petgraph` without too much effort. We'll loose some of the refined API, especially walking graphs via iterators, but it doesn't really matter too much as the `Acyclic` type, "a wrapper around graph types that enforces an acyclicity invariant", works well enough (just a bit less "refined").

We also already used `petgraph` directly for the `tree-of` command. This direct dependency on `petgraph` became the trigger for dropping the dependency on `daggy` since `petgraph` yanked the release of version `0.6.6` with the new release of version `0.7.0` [1] and the resulting CI failure for the `petgraph` update [2] made me take a closer look at the situation (we don't necessarily have to drop `daggy` just yet but it seems for the best given it's unclear future and the duplicated `petgraph` dependency that causes incompatibilities / build failures).

[0]: https://github.com/mitchmindtree/daggy
[1]: https://github.com/petgraph/petgraph/issues/712
[2]: https://github.com/science-computing/butido/pull/446

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
