### PR TITLE
Update the Rust edition from 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
   "Nico Steinle <nico.steinle@eviden.com>", # @ammernico
   "Michael Weiss <michael.weiss@eviden.com>", # @primeos-work
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.0" # MSRV
 license = "EPL-2.0"
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
-edition = "2021"
+edition = "2024"
+style_edition = "2021"
 newline_style = "Unix"

--- a/src/endpoint/configured.rs
+++ b/src/endpoint/configured.rs
@@ -269,8 +269,8 @@ impl Endpoint {
     pub async fn container_stats(&self) -> Result<Vec<ContainerStat>> {
         self.docker
             .containers()
-            .list({
-                &shiplift::builder::ContainerListOptions::builder()
+            .list(&{
+                shiplift::builder::ContainerListOptions::builder()
                     .all()
                     .build()
             })
@@ -297,7 +297,10 @@ impl Endpoint {
         }
     }
 
-    pub async fn images(&self, name_filter: Option<&str>) -> Result<impl Iterator<Item = Image>> {
+    pub async fn images(
+        &self,
+        name_filter: Option<&str>,
+    ) -> Result<impl Iterator<Item = Image> + use<>> {
         let mut listopts = shiplift::builder::ImageListOptions::builder();
 
         if let Some(name) = name_filter {

--- a/src/filestore/path.rs
+++ b/src/filestore/path.rs
@@ -79,7 +79,7 @@ impl StoreRoot {
 
     pub(in crate::filestore) fn find_artifacts_recursive(
         &self,
-    ) -> impl Iterator<Item = Result<ArtifactPath>> {
+    ) -> impl Iterator<Item = Result<ArtifactPath>> + use<> {
         trace!("Loading artifacts from directory: {:?}", self.0);
         let root = self.0.clone();
         walkdir::WalkDir::new(&self.0)

--- a/src/repository/fs/element.rs
+++ b/src/repository/fs/element.rs
@@ -26,7 +26,7 @@ impl Element {
     pub fn get_map_mut(&mut self) -> Option<&mut HashMap<PathComponent, Element>> {
         match self {
             Element::File(_) => None,
-            Element::Dir(ref mut hm) => Some(hm),
+            Element::Dir(hm) => Some(hm),
         }
     }
 }

--- a/src/util/filters.rs
+++ b/src/util/filters.rs
@@ -25,7 +25,7 @@ pub fn build_package_filter_by_dependency_name(
     name: &PackageName,
     check_build_dep: bool,
     check_runtime_dep: bool,
-) -> impl filters::failable::filter::FailableFilter<Package, Error = Error> {
+) -> impl filters::failable::filter::FailableFilter<Package, Error = Error> + use<> {
     let n = name.clone(); // clone, so we can move into closure
     let filter_build_dep = move |p: &Package| -> Result<bool> {
         trace!(


### PR DESCRIPTION
See "The Rust Edition Guide" [0] for details regarding the changes in Rust 2024. I started with `cargo fix --edition` [1] but ended up reverting the "unnecessary" `if let` to `match` conversions [2] and had to preform a manual change for the tail expression temporary scope [3] (in the `container_stats()` function).
Other relevant changes are [4] (we could revert the change in `path.rs`) and [5].

I also manually updated the edition in `rustfmt.toml` and set the new `style_edition` [6] to `2021` to split the formatting changes into a dedicated commit (will be done later).

[0]: https://doc.rust-lang.org/edition-guide/rust-2024/index.html
[1]: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
[2]: https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html
[3]: https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html
[4]: https://doc.rust-lang.org/edition-guide/rust-2024/rpit-lifetime-capture.html
[5]: https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html
[6]: https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=edition#style_edition

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
