### PR TITLE
Fix all new Clippy warnings from version 1.87

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -304,7 +304,7 @@ pub async fn build(
             }
 
             if let Some(deniedlist) = pkg.denied_images() {
-                if deniedlist.iter().any(|denied| image_name == *denied) {
+                if deniedlist.contains(&image_name) {
                     anyhow::bail!(
                         "Package {} {} is not allowed to be built on {}",
                         pkg.name(),

--- a/src/log/parser.rs
+++ b/src/log/parser.rs
@@ -31,7 +31,7 @@ where
 {
     stream
         .map(|r| r.map(TtyChunkBuf::from))
-        .map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
+        .map_err(futures::io::Error::other)
         .into_async_read()
         .lines()
 }

--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -281,7 +281,7 @@ impl TreeItem for DagDisplay<'_> {
             .dag
             .node_weight(self.1)
             .ok_or_else(|| anyhow!("Error finding node: {:?}", self.1))
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
         let dependency_type = match self.2 {
             // Only the root package has no edge and we pretend it's a runtime dependency as we
             // only mark build time dependencies in the output:
@@ -291,7 +291,7 @@ impl TreeItem for DagDisplay<'_> {
                 .dag
                 .edge_weight(edge_idx)
                 .ok_or_else(|| anyhow!("Error finding edge: {:?}", self.2))
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
+                .map_err(std::io::Error::other)?,
         };
         let extra_info = match dependency_type {
             // We mark build time dependencies with a star:

--- a/src/util/docker.rs
+++ b/src/util/docker.rs
@@ -98,6 +98,7 @@ impl ImageNameLookup {
     }
 
     // To convert a user-supplied image name into an expanded image name:
+    #[rustversion::attr(all(since(1.87), before(1.88)), allow(clippy::map_entry))]
     pub fn expand(&self, image_name: &str) -> Result<ImageName> {
         let image_name = ImageName::from(image_name.to_string());
         if self.long2short.contains_key(&image_name) {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
62a250d Fix a Clippy warning from the `manual_contains` lint
bdaa374 Ignore a false-positive Clippy warning from the `map_entry` lint
5168ad9 Make use of the `io::Error::other` shortcut