### PR TITLE
Downgrade the deranged crate since version 0.4.1 got yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]


### PR DESCRIPTION
The maintainer yanked version 0.4.1:
- https://crates.io/crates/deranged/0.4.1
- https://github.com/jhpratt/deranged/issues/21
- https://github.com/jhpratt/deranged/issues/19
- https://github.com/jhpratt/deranged/issues/18
- https://github.com/jhpratt/deranged/issues/17

It doesn't really seem to affect us yet but let's "upgrade" to the newest non-yanked version to make our CI check green again.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
