### PR TITLE
deny.toml: Cleanup Unicode-DFS-2016 from the list of allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,6 @@ allow = [
     "MIT",
     "MPL-2.0",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Zlib"
 ]
 


### PR DESCRIPTION
It simply isn't required anymore and only generates an unnecessary `license-not-encountered` warning message (which is actually the case for quite a while now).

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
