### PR TITLE
Fix warnings from the `mismatched_lifetime_syntaxes` lint

### DIFF
--- a/src/filestore/path.rs
+++ b/src/filestore/path.rs
@@ -73,7 +73,7 @@ impl StoreRoot {
         self.0.join(subpath).is_dir()
     }
 
-    pub fn display(&self) -> std::path::Display {
+    pub fn display(&self) -> std::path::Display<'_> {
         self.0.display()
     }
 
@@ -164,7 +164,7 @@ impl ArtifactPath {
         ArtifactPath(root)
     }
 
-    pub fn display(&self) -> std::path::Display {
+    pub fn display(&self) -> std::path::Display<'_> {
         self.0.display()
     }
 

--- a/src/job/dag.rs
+++ b/src/job/dag.rs
@@ -51,7 +51,7 @@ impl Dag {
         }
     }
 
-    pub fn iter(&'_ self) -> impl Iterator<Item = JobDefinition> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = JobDefinition<'_>> {
         self.dag.node_indices().map(move |idx| {
             let job = self.dag.node_weight(idx).unwrap(); // TODO
             let children = self.dag.neighbors_directed(idx, petgraph::Outgoing);

--- a/src/package/dag.rs
+++ b/src/package/dag.rs
@@ -264,7 +264,7 @@ impl Dag {
             .collect()
     }
 
-    pub fn display(&self) -> DagDisplay {
+    pub fn display(&self) -> DagDisplay<'_> {
         DagDisplay(self, self.root_idx, None)
     }
 }
@@ -301,7 +301,7 @@ impl TreeItem for DagDisplay<'_> {
         write!(f, "{}{} {}", extra_info, p.name(), p.version())
     }
 
-    fn children(&self) -> Cow<[Self::Child]> {
+    fn children(&self) -> Cow<'_, [Self::Child]> {
         let mut children_walker = self
             .0
             .dag

--- a/src/ui/package.rs
+++ b/src/ui/package.rs
@@ -101,7 +101,7 @@ pub struct PreparePrintPackage<'a, P: Borrow<Package>> {
     i: usize,
 }
 
-pub fn handlebars_for_package_printing(format: &str) -> Result<Handlebars> {
+pub fn handlebars_for_package_printing(format: &str) -> Result<Handlebars<'_>> {
     let mut hb = Handlebars::new();
     hb.register_escape_fn(handlebars::no_escape);
     hb.register_template_string("package", format)?;


### PR DESCRIPTION
This fixes warnings from a new `rustc_lint` [0] that got added in rustc version 1.89.0 (currently still in beta).

[0]: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
