### PR TITLE
Switch our email addresses from Eviden to Bull

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.5.0"
 authors = [
   # Only for the current/active maintainers (sorted alphabetically by the surname)
   # All other authors are listed in the "Authors" section of README.md
-  "Nico Steinle <nico.steinle@eviden.com>", # @ammernico
-  "Michael Weiss <michael.weiss@eviden.com>", # @primeos-work
+  "Nico Steinle <nico.steinle@bull.com>", # @ammernico
+  "Michael Weiss <michael.weiss@bull.com>", # @primeos-work
 ]
 edition = "2024"
 rust-version = "1.88.0" # MSRV

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ cd /tmp/butido-test-repo
 - Original author: Matthias Beyer <mail@beyermatthias.de> @matthiasbeyer
 - Active maintainers: See `authors` in Cargo.toml
 - Passive maintainers
-  - Erdmut Pfeifer <erdmut.pfeifer@eviden.com> @ErdmutPfeifer
-  - Christoph Prokop <christoph.prokop@eviden.com> @christophprokop
+  - Erdmut Pfeifer <erdmut.pfeifer@bull.com> @ErdmutPfeifer
+  - Christoph Prokop <christoph.prokop@bull.com> @christophprokop
 
 
 # License
 
-butido was developed for science + computing AG (an Atos company).
+butido was developed for science + computing AG (a Bull business).
 
 License: EPL-2.0


### PR DESCRIPTION
Our parent company got renamed to Bull:
- https://www.bull.com/en/press-releases/brand-launch
- https://www.bull.com/en/press-releases/the-french-state-finalises-the-acquisition-of-bull-and-positions-france-at-the-forefront-of-high-performance-computing-and-ai
- https://www.bull.com/en/solutions/consulting/product-engineering-it-consulting

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
