### PR TITLE
Sort artifact list alphabetically

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -423,6 +423,7 @@ pub async fn build(
     if !artifacts.is_empty() {
         writeln!(outlock, "Packages created:")?;
     }
+    artifacts.sort_by_key(|a| a.as_ref().to_string_lossy().to_lowercase());
     artifacts.into_iter().try_for_each(|artifact_path| {
         writeln!(outlock, "{}", staging_dir.join(artifact_path).display()).map_err(Error::from)
     })?;


### PR DESCRIPTION
Sort the artifact output vector by the artifacts' lowercase path names before printing. This makes the "Packages created" output easier to scan.

- Printing still uses the original path form.

<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
