### PR TITLE
Fix all CI warnings (Clippy + cargo-deny)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,4 +70,9 @@ ignore = [
     # https://github.com/trishume/syntect/issues/606 is resolved
     # ("Replacement for bincode as a dep?"):
     { id = "RUSTSEC-2025-0141", reason = "Only an informative advisory that the crate is unmaintained but the team considers version 1.3.3 a complete version that is not in need of any updates." },
+    # Ignore an "INFO Unmaintained" advisory for the `proc-macro-error2` crate
+    # that the `aquamarine` crate uses. This can be removed once
+    # https://github.com/mersinvald/aquamarine/issues/57 is resolved
+    # ("RUSTSEC-2026-0173: proc-macro-error2 is unmaintained"):
+    { id = "RUSTSEC-2026-0173", reason = "Only an informative advisory that the crate is unmaintained and the author recommends that users migrate away from it." },
 ]

--- a/src/commands/source/download.rs
+++ b/src/commands/source/download.rs
@@ -142,7 +142,7 @@ async fn perform_download(
 
     let response = match client.execute(request).await {
         Ok(resp) => resp,
-        Err(e) => return Err(e).with_context(|| anyhow!("Downloading '{}'", &source.url())),
+        Err(e) => return Err(e).with_context(|| anyhow!("Downloading '{}'", source.url())),
     };
 
     if response.status() != reqwest::StatusCode::OK {
@@ -151,7 +151,7 @@ async fn perform_download(
             response.status(),
             reqwest::StatusCode::OK
         ))
-        .with_context(|| anyhow!("Downloading \"{}\" failed", &source.url()));
+        .with_context(|| anyhow!("Downloading \"{}\" failed", source.url()));
     }
 
     progress

--- a/src/repository/fs/representation.rs
+++ b/src/repository/fs/representation.rs
@@ -162,7 +162,7 @@ impl FileSystemRepresentation {
             anyhow!(
                 "The path `{}` doesn't include the repo root `{}`",
                 path.display(),
-                &self.root.display()
+                self.root.display()
             )
         })?;
         let mut curr_hm = &self.elements;
@@ -203,7 +203,7 @@ impl FileSystemRepresentation {
             anyhow!(
                 "The path `{}` doesn't include the repo root `{}`",
                 path.display(),
-                &self.root.display()
+                self.root.display()
             )
         })?;
         let mut curr_hm = &self.elements;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md first and consider the checklist. -->
- cb5388f: Fix Clippy warnings from the `useless_borrows_in_formatting` lint
- 6c40375: Let cargo-deny ignore that the proc-macro-error2 crate is unmaintained